### PR TITLE
Feature/json helper

### DIFF
--- a/Sources/BadgeCount.swift
+++ b/Sources/BadgeCount.swift
@@ -31,7 +31,7 @@ public struct BadgeCount: JsonConvertible, CustomStringConvertible {
     }
     
     public var jsonString: String? {
-        return JsonHelper.jsonString(from: self)
+        return (try? JsonHelper.jsonString(from: self)) ?? nil
     }
     
     public var description: String {

--- a/Sources/BadgeCount.swift
+++ b/Sources/BadgeCount.swift
@@ -31,14 +31,7 @@ public struct BadgeCount: JsonConvertible, CustomStringConvertible {
     }
     
     public var jsonString: String? {
-        do {
-            let data = try JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted)
-            
-            let string = String(data: data, encoding: .utf8)
-            return string
-        } catch {
-            return nil
-        }
+        return JsonHelper.jsonString(from: self)
     }
     
     public var description: String {

--- a/Sources/JsonHelper.swift
+++ b/Sources/JsonHelper.swift
@@ -185,4 +185,29 @@ public struct JsonHelper {
     }
     
     
+    // - MARK: Decode JSON-String
+    
+    /**
+     Decodes a given JSON-string
+     
+     - note: Unlike the `jsonString(from:)` method, this will not convert the String to custom objects. You will have to use their initializers.
+     
+     - note: Try to avoid this method. It's easier to use the JSON-initializer of `JsonConvertible` objects.
+     
+     - parameter json: The JSON-string
+     
+     - returns: An object or `nil`, if the decoding failed.
+     
+     - author: FelixSFD
+     */
+    public static func decode(jsonString json: String) -> Any? {
+        do {
+            return try JSONSerialization.jsonObject(with: json.data(using: String.Encoding.utf8)!, options: .allowFragments)
+        } catch {
+            //ERROR
+            return nil
+        }
+    }
+    
+    
 }

--- a/Sources/JsonHelper.swift
+++ b/Sources/JsonHelper.swift
@@ -1,0 +1,188 @@
+//
+//  JsonHelper.swift
+//  SwiftStack
+//
+//  Created by FelixSFD on 08.12.16.
+//
+//
+
+import Foundation
+
+/**
+ An array that only contains objects that can be represented in a JSON string.
+ */
+public typealias EncodedArray = [Any]
+
+/**
+ A dictionary that only contains objects that can be represented in a JSON string.
+ */
+public typealias EncodedDictionary = [String: Any]
+
+/**
+ Helps to convert dictionaries/arrays with custom objects to a valid JSON string. (and back)
+ 
+ - author: FelixSFD
+ */
+public struct JsonHelper {
+    // - MARK: Prepare objects for encoding
+    
+    /**
+     Encodes the contents of a dictionary recursively.
+     
+     - author: FelixSFD
+     */
+    public static func encode(object: [String: Any]) -> EncodedDictionary {
+        var dict = object
+        for key in dict.keys {
+            if dict[key] is Date {
+                dict[key] = JsonHelper.encode(object: dict[key] as! Date)
+            }
+            
+            if dict[key] is DictionaryConvertible {
+                dict[key] = JsonHelper.encode(object: dict[key] as! DictionaryConvertible)
+            }
+            
+            if dict[key] is StringRepresentable {
+                dict[key] = JsonHelper.encode(object: dict[key] as! StringRepresentable)
+            }
+            
+            if dict[key] is URL {
+                dict[key] = JsonHelper.encode(object: dict[key] as! URL)
+            }
+        }
+        
+        return dict
+    }
+    
+    /**
+     Encodes the contents of an array recursively.
+     
+     - author: FelixSFD
+     
+     - seealso `encode(object: [String: Any])`
+     */
+    public static func encode(object: [Any]) -> EncodedArray {
+        var array = object
+        for (index, item) in array.enumerated() {
+            if array[index] is Date {
+                array[index] = JsonHelper.encode(object: item as! Date)
+            }
+            
+            if array[index] is DictionaryConvertible {
+                array[index] = JsonHelper.encode(object: item as! DictionaryConvertible)
+            }
+            
+            if array[index] is StringRepresentable {
+                array[index] = JsonHelper.encode(object: item as! StringRepresentable)
+            }
+            
+            if array[index] is URL {
+                array[index] = JsonHelper.encode(object: item as! URL)
+            }
+        }
+        
+        return array
+    }
+    
+    /**
+     Encodes dictionary convertibles like `User`.
+     */
+    public static func encode(object: DictionaryConvertible) -> EncodedDictionary {
+        return JsonHelper.encode(object: object.dictionary)
+    }
+    
+    /**
+     Encodes objects that conform to `StringRepresentable`.
+     */
+    public static func encode(object: StringRepresentable) -> String {
+        return object.rawValue
+    }
+    
+    
+    /**
+     Returns the UNIX timestamp from the `Date`
+     */
+    public static func encode(object: Date) -> Int {
+        return Int(object.timeIntervalSince1970)
+    }
+    
+    /**
+     Returns the absolute string of the `URL`.
+     */
+    public static func encode(object: URL) -> String {
+        return object.absoluteString
+    }
+    
+    // - MARK: Encode to JSON-string
+    
+    /**
+     Encodes a `[String: Any]` to a valid JSON-string.
+     
+     - parameter dictionary: The dictionary to encode
+     
+     - returns: The JSON-string or `nil` if an error occurred
+     
+     - author: FelixSFD
+     */
+    public static func jsonString(from dictionary: [String: Any]) -> String? {
+        do {
+            let encoded = JsonHelper.encode(object: dictionary)
+            let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
+            
+            let string = String(data: data, encoding: .utf8)
+            
+            return string
+        } catch {
+            //ERROR
+            return nil
+        }
+    }
+    
+    /**
+     Encodes a `[Any]` to a valid JSON-string.
+     
+     - parameter array: The array to encode
+     
+     - returns: The JSON-string or `nil` if an error occurred
+     
+     - author: FelixSFD
+     */
+    public static func jsonString(from array: [Any]) -> String? {
+        do {
+            let encoded = JsonHelper.encode(object: array)
+            let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
+            
+            let string = String(data: data, encoding: .utf8)
+            
+            return string
+        } catch {
+            //ERROR
+            return nil
+        }
+    }
+    
+    /**
+     Encodes a `DictionaryConvertible` to a valid JSON-string.
+     
+     - parameter object: The object to encode
+     
+     - returns: The JSON-string or `nil` if an error occurred
+     
+     - author: FelixSFD
+     */
+    public static func jsonString(from object: DictionaryConvertible) -> String? {
+        do {
+            let encoded = JsonHelper.encode(object: object)
+            let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
+            
+            let string = String(data: data, encoding: .utf8)
+            
+            return string
+        } catch {
+            //ERROR
+            return nil
+        }
+    }
+    
+    
+}

--- a/Sources/JsonHelper.swift
+++ b/Sources/JsonHelper.swift
@@ -120,22 +120,19 @@ public struct JsonHelper {
      
      - parameter dictionary: The dictionary to encode
      
-     - returns: The JSON-string or `nil` if an error occurred
+     - returns: The JSON-string
+     
+     - throws: An error if the decoding failed
      
      - author: FelixSFD
      */
-    public static func jsonString(from dictionary: [String: Any]) -> String? {
-        do {
-            let encoded = JsonHelper.encode(object: dictionary)
-            let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
-            
-            let string = String(data: data, encoding: .utf8)
-            
-            return string
-        } catch {
-            //ERROR
-            return nil
-        }
+    public static func jsonString(from dictionary: [String: Any]) throws -> String? {
+        let encoded = JsonHelper.encode(object: dictionary)
+        let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
+        
+        let string = String(data: data, encoding: .utf8)
+        
+        return string
     }
     
     /**
@@ -143,22 +140,19 @@ public struct JsonHelper {
      
      - parameter array: The array to encode
      
-     - returns: The JSON-string or `nil` if an error occurred
+     - returns: The JSON-string
+     
+     - throws: An error if the decoding failed
      
      - author: FelixSFD
      */
-    public static func jsonString(from array: [Any]) -> String? {
-        do {
-            let encoded = JsonHelper.encode(object: array)
-            let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
-            
-            let string = String(data: data, encoding: .utf8)
-            
-            return string
-        } catch {
-            //ERROR
-            return nil
-        }
+    public static func jsonString(from array: [Any]) throws -> String? {
+        let encoded = JsonHelper.encode(object: array)
+        let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
+        
+        let string = String(data: data, encoding: .utf8)
+        
+        return string
     }
     
     /**
@@ -166,22 +160,19 @@ public struct JsonHelper {
      
      - parameter object: The object to encode
      
-     - returns: The JSON-string or `nil` if an error occurred
+     - returns: The JSON-string
+     
+     - throws: An error if the decoding failed
      
      - author: FelixSFD
      */
-    public static func jsonString(from object: DictionaryConvertible) -> String? {
-        do {
-            let encoded = JsonHelper.encode(object: object)
-            let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
+    public static func jsonString(from object: DictionaryConvertible) throws -> String? {
+        let encoded = JsonHelper.encode(object: object)
+        let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
             
-            let string = String(data: data, encoding: .utf8)
+        let string = String(data: data, encoding: .utf8)
             
-            return string
-        } catch {
-            //ERROR
-            return nil
-        }
+        return string
     }
     
     
@@ -196,17 +187,14 @@ public struct JsonHelper {
      
      - parameter json: The JSON-string
      
-     - returns: An object or `nil`, if the decoding failed.
+     - returns: The decoded object
+     
+     - throws: An error if the decoding failed
      
      - author: FelixSFD
      */
-    public static func decode(jsonString json: String) -> Any? {
-        do {
-            return try JSONSerialization.jsonObject(with: json.data(using: String.Encoding.utf8)!, options: .allowFragments)
-        } catch {
-            //ERROR
-            return nil
-        }
+    public static func decode(jsonString json: String) throws -> Any {
+        return try JSONSerialization.jsonObject(with: json.data(using: String.Encoding.utf8)!, options: .allowFragments)
     }
     
     

--- a/Sources/JsonHelper.swift
+++ b/Sources/JsonHelper.swift
@@ -169,9 +169,9 @@ public struct JsonHelper {
     public static func jsonString(from object: DictionaryConvertible) throws -> String? {
         let encoded = JsonHelper.encode(object: object)
         let data = try JSONSerialization.data(withJSONObject: encoded, options: .prettyPrinted)
-            
+        
         let string = String(data: data, encoding: .utf8)
-            
+        
         return string
     }
     

--- a/Sources/StringRepresentable.swift
+++ b/Sources/StringRepresentable.swift
@@ -1,0 +1,21 @@
+//
+//  StringRepresentable.swift
+//  SwiftStack
+//
+//  Created by FelixSFD on 08.12.16.
+//
+//
+
+import Foundation
+
+/**
+ Objects that can represented as a `String` conform to this protocol.
+ 
+ - note: This is similar to `RawRepresentable`, but is NOT the same.
+ 
+ - author: FelixSFD
+ */
+public protocol StringRepresentable {
+    var rawValue: String { get }
+    init?(rawValue: String)
+}

--- a/Sources/User.swift
+++ b/Sources/User.swift
@@ -206,7 +206,7 @@ public class User: JsonConvertible, CustomStringConvertible {
     }
     
     public var jsonString: String? {
-        return JsonHelper.jsonString(from: self)
+        return (try? JsonHelper.jsonString(from: self)) ?? nil
     }
     
     // - MARK: CustomStrinConvertible

--- a/Sources/User.swift
+++ b/Sources/User.swift
@@ -52,7 +52,7 @@ public class User: JsonConvertible, CustomStringConvertible {
      
      - seealso: [StackExchange API](https://api.stackexchange.com/docs/types/user)
      */
-    public enum UserType: String {
+    public enum UserType: String, StringRepresentable {
         case unregistered = "unregistered"
         case registered = "registered"
         case moderator = "moderator"
@@ -198,7 +198,7 @@ public class User: JsonConvertible, CustomStringConvertible {
         dict["timed_penalty_date"] = timed_penalty_date
         dict["up_vote_count"] = up_vote_count
         dict["user_id"] = user_id
-        dict["user_type"] = user_type?.rawValue
+        dict["user_type"] = user_type
         dict["view_count"] = view_count
         dict["website_url"] = website_url
         
@@ -206,30 +206,7 @@ public class User: JsonConvertible, CustomStringConvertible {
     }
     
     public var jsonString: String? {
-        //convert objects back to their original type as returned by the API
-        var tmpDictionary = dictionary
-        for key in tmpDictionary.keys {
-            
-            //Date to timestamp
-            if tmpDictionary[key] is Date {
-                tmpDictionary[key] = (tmpDictionary[key] as? Date)?.timeIntervalSince1970
-            }
-            
-            //URL to String
-            if tmpDictionary[key] is URL {
-                tmpDictionary[key] = (tmpDictionary[key] as? URL)?.absoluteString
-            }
-        }
-        
-        
-        do {
-            let data = try JSONSerialization.data(withJSONObject: tmpDictionary, options: .prettyPrinted)
-            
-            let string = String(data: data, encoding: .utf8)
-            return string
-        } catch {
-            return nil
-        }
+        return JsonHelper.jsonString(from: self)
     }
     
     // - MARK: CustomStrinConvertible

--- a/Tests/SwiftStackTests/JsonHelperTests.swift
+++ b/Tests/SwiftStackTests/JsonHelperTests.swift
@@ -21,9 +21,9 @@ class JsonHelperTests: XCTestCase {
         print(encoded)
         XCTAssertNotNil(encoded)*/
         
-        let jsonUser = user?.jsonString
-        print(jsonUser)
-        XCTAssertNotNil(jsonUser)
+		let jsonUser = user?.jsonString
+		print(jsonUser ?? "nil")
+		XCTAssertNotNil(jsonUser)
     }
     
 }

--- a/Tests/SwiftStackTests/JsonHelperTests.swift
+++ b/Tests/SwiftStackTests/JsonHelperTests.swift
@@ -1,0 +1,29 @@
+//
+//  JsonHelperTests.swift
+//  SwiftStack
+//
+//  Created by FelixSFD on 08.12.16.
+//
+//
+
+import XCTest
+import SwiftStack
+
+class JsonHelperTests: XCTestCase {
+    
+    func testEncoding() {
+        let json = "{\"badge_counts\": {\"bronze\": 3,\"silver\": 2,\"gold\": 1},\"view_count\": 1000,\"down_vote_count\": 50,\"up_vote_count\": 90,\"answer_count\": 10,\"question_count\": 12,\"account_id\": 1,\"is_employee\": false,\"last_modified_date\": 1480858104,\"last_access_date\": 1480901304,\"age\": 40,\"reputation_change_year\": 9001,\"reputation_change_quarter\": 400,\"reputation_change_month\": 200,\"reputation_change_week\": 800,\"reputation_change_day\": 100,\"reputation\": 9001,\"creation_date\": 1480858104,\"user_type\": \"registered\",\"user_id\": 1,\"accept_rate\": 55,\"about_me\": \"about me block\",\"location\": \"An Imaginary World\",\"website_url\": \"http://example.com/\",\"link\": \"http://example.stackexchange.com/users/1/example-user\",\"profile_image\": \"https://www.gravatar.com/avatar/a007be5a61f6aa8f3e85ae2fc18dd66e?d=identicon&r=PG\",\"display_name\": \"Example User\"}"
+        
+        let user = User(jsonString: json)
+        
+        /*let encoded = JsonHelper.encode(object: user!)
+        
+        print(encoded)
+        XCTAssertNotNil(encoded)*/
+        
+        let jsonUser = user?.jsonString
+        print(jsonUser)
+        XCTAssertNotNil(jsonUser)
+    }
+    
+}

--- a/Tests/SwiftStackTests/UserTests.swift
+++ b/Tests/SwiftStackTests/UserTests.swift
@@ -21,7 +21,7 @@ class UserTests: XCTestCase {
         let json = "{\"badge_counts\": {\"bronze\": 3,\"silver\": 2,\"gold\": 1},\"view_count\": 1000,\"down_vote_count\": 50,\"up_vote_count\": 90,\"answer_count\": 10,\"question_count\": 12,\"account_id\": 1,\"is_employee\": false,\"last_modified_date\": 1480858104,\"last_access_date\": 1480901304,\"age\": 40,\"reputation_change_year\": 9001,\"reputation_change_quarter\": 400,\"reputation_change_month\": 200,\"reputation_change_week\": 800,\"reputation_change_day\": 100,\"reputation\": 9001,\"creation_date\": 1480858104,\"user_type\": \"registered\",\"user_id\": 1,\"accept_rate\": 55,\"about_me\": \"about me block\",\"location\": \"An Imaginary World\",\"website_url\": \"http://example.com/\",\"link\": \"http://example.stackexchange.com/users/1/example-user\",\"profile_image\": \"https://www.gravatar.com/avatar/a007be5a61f6aa8f3e85ae2fc18dd66e?d=identicon&r=PG\",\"display_name\": \"Example User\"}"
         
         let user = User(jsonString: json)
-        print(user)
+        print(user ?? "nil")
         
         if user?.jsonString == nil {
             XCTFail("User could not be represented as JSON!")


### PR DESCRIPTION
## Introduced classes

### JsonHelper

This class helps to encode/decode JSON-strings. When encoding `DictionaryConvertible`s, they will automatically be encoded to a format the API can use. (for example `Date`s will be converted to an UNIX-timestamp)

## Introduced protocols

### StringRepresentable

This is similar to `RawRepresentable`, but can be used as type. Enums inheriting from `String` should conform to this protocol in order to be encoded correctly in `JsonHelper`.


## Changes that should be made after the pull-reuqest

Other existing classes/structs that conform to `JsonConvertible` should use the `JsonHelper`.

All enums within these objects that inherit from `String` should conform to `StringRepresentable`.

The `jsonString` property of `JsonConvertible`s should now look like this:

```
var jsonString: String? {
    return (try? JsonHelper.jsonString(from: self)) ?? nil
}
```