### PR TITLE
Documentation with Jazzy

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,0 +1,6 @@
+module: SwiftStack
+author: NobodyNada & FelixSFD
+author_url: https://github.com/NobodyNada/SwiftStack
+github_url: https://github.com/NobodyNada/SwiftStack
+github_file_prefix: https://github.com/NobodyNada/SwiftStack/tree/0.1.0
+module_version: 0.1.0

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,5 +2,5 @@ module: SwiftStack
 author: NobodyNada & FelixSFD
 author_url: https://github.com/NobodyNada/SwiftStack
 github_url: https://github.com/NobodyNada/SwiftStack
-github_file_prefix: https://github.com/NobodyNada/SwiftStack/tree/0.1.0
+github_file_prefix: https://github.com/NobodyNada/SwiftStack/blob/0.1.0
 module_version: 0.1.0


### PR DESCRIPTION
I've added a configuration-file to create documentation-files with [Jazzy](https://github.com/realm/jazzy).

This is how the documentation could look like:
[sample-docs.zip](https://github.com/NobodyNada/SwiftStack/files/659575/sample-docs.zip)

--

To generate the docs (assuming that you have installed jazzy), run this command in the root-folder of SwiftStack:

    jazzy --output ../docs