### PR TITLE
Question and Answer should fill in the post_id field

### DIFF
--- a/Sources/Answer.swift
+++ b/Sources/Answer.swift
@@ -17,6 +17,7 @@ public class Answer: Post {
         
         self.accepted = dictionary["accepted"] as? Bool
         self.answer_id = dictionary["answer_id"] as? Int
+		self.post_id = answer_id
         self.awarded_bounty_amount = dictionary["awarded_bounty_amount"] as? Int
         
         if let users = dictionary["awarded_bounty_users"] as? [[String: Any]] {

--- a/Sources/Question.swift
+++ b/Sources/Question.swift
@@ -268,6 +268,7 @@ public class Question: Post {
         }
         
         self.question_id = dictionary["question_id"] as? Int
+		self.post_id = question_id
         self.reopen_vote_count = dictionary["reopen_vote_count"] as? Int
         self.tags = dictionary["tags"] as? [String]
         


### PR DESCRIPTION
Right now, the `post_id` field is `nil` for questions & answers.  This was breaking FireAlarm, so I made a quick change to fill in the `post_id` fields.