### PR TITLE
Swiftier API

### DIFF
--- a/Sources/APIClient.swift
+++ b/Sources/APIClient.swift
@@ -96,7 +96,7 @@ open class APIClient: NSObject, URLSessionDataDelegate {
 	///- parameter parameters: Parameters to be URLEncoded into the request.
 	open func performAPIRequest<T>(
 		_ request: String,
-		_ parameters: [String:String] = [:],
+		parameters: [String:String] = [:],
 		backoffBehavior: BackoffBehavior = .wait
 		) throws -> APIResponse<T> {
 		
@@ -249,7 +249,7 @@ open class APIClient: NSObject, URLSessionDataDelegate {
 	///	- fields: The data to POST.
 	///
 	///- returns: The data and response returned by the request.
-	open func post(_ url: String, _ fields: [String:String]) throws -> (Data, HTTPURLResponse) {
+	open func post(_ url: String, fields: [String:String]) throws -> (Data, HTTPURLResponse) {
 		guard let nsUrl = URL(string: url) else {
 			throw RequestError.invalidURL(url: url)
 		}
@@ -326,8 +326,8 @@ open class APIClient: NSObject, URLSessionDataDelegate {
 	///	- fields: The data to POST.
 	///
 	///- returns: The text returned by the request.
-	open func post(_ url: String, _ fields: [String:String]) throws -> String {
-		let (data, _) = try post(url, fields)
+	open func post(_ url: String, fields: [String:String]) throws -> String {
+        let (data, _) = try post(url, fields: fields)
 		guard let string = String(data: data, encoding: String.Encoding.utf8) else {
 			throw RequestError.notUTF8
 		}

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -32,7 +32,7 @@ public extension APIClient {
      */
 	public func fetchQuestions(
 		_ ids: [Int],
-		_ parameters: [String:String] = [:],
+		parameters: [String:String] = [:],
 		backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
 		
 		guard !ids.isEmpty else {
@@ -62,7 +62,7 @@ public extension APIClient {
      */
     public func fetchQuestions(
 		_ ids: [Int],
-		_ parameters: [String: String] = [:],
+		parameters: [String: String] = [:],
 		backoffBehavior: BackoffBehavior = .wait,
 		completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
         
@@ -70,7 +70,7 @@ public extension APIClient {
             do {
 				let response: APIResponse<Question> = try self.fetchQuestions(
 					ids,
-					parameters,
+					parameters: parameters,
 					backoffBehavior: backoffBehavior
 				)
 				
@@ -97,10 +97,10 @@ public extension APIClient {
 	*/
 	public func fetchQuestion(
 		_ id: Int,
-		_ parameters: [String:String] = [:],
+		parameters: [String:String] = [:],
 		backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
 		
-		return try fetchQuestions([id], parameters, backoffBehavior: backoffBehavior)
+		return try fetchQuestions([id], parameters: parameters, backoffBehavior: backoffBehavior)
 	}
 	
 	/**
@@ -118,11 +118,11 @@ public extension APIClient {
 	*/
 	public func fetchQuestion(
 		_ id: Int,
-		_ parameters: [String: String] = [:],
+		parameters: [String: String] = [:],
 		backoffBehavior: BackoffBehavior = .wait,
 		completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
 		
-		fetchQuestions([id], parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
+		fetchQuestions([id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
 	}
 	
 }

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -42,7 +42,7 @@ public extension APIClient {
 		
 		return try performAPIRequest(
 			"questions/\(ids.map {String($0)}.joined(separator: ";"))",
-			parameters,
+			parameters: parameters,
 			backoffBehavior: backoffBehavior
 		)
 	}

--- a/Sources/RequestsSites.swift
+++ b/Sources/RequestsSites.swift
@@ -29,7 +29,7 @@ public extension APIClient {
      - author: NobodyNada
      */
 	public func fetchSites(
-		_ parameters: [String:String] = [:],
+		parameters: [String:String] = [:],
 		backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Site> {
 		
 		
@@ -52,12 +52,12 @@ public extension APIClient {
      
      - author: FelixSFD
      */
-    public func fetchSites(_ parameters: [String: String] = [:], backoffBehavior: BackoffBehavior = .wait, completionHandler: @escaping (APIResponse<Site>?, Error?) -> ()) {
+    public func fetchSites(parameters: [String: String] = [:], backoffBehavior: BackoffBehavior = .wait, completionHandler: @escaping (APIResponse<Site>?, Error?) -> ()) {
         
         queue.async {
             
             do {
-                let response: APIResponse<Site> = try self.fetchSites(parameters, backoffBehavior: backoffBehavior)
+                let response: APIResponse<Site> = try self.fetchSites(parameters: parameters, backoffBehavior: backoffBehavior)
                 completionHandler(response, nil)
             } catch {
                 completionHandler(nil, error)

--- a/Sources/RequestsSites.swift
+++ b/Sources/RequestsSites.swift
@@ -38,7 +38,7 @@ public extension APIClient {
 		
 		return try performAPIRequest(
 			"sites",
-			params,
+			parameters: params,
 			backoffBehavior: backoffBehavior
 		)
 	}

--- a/Tests/SwiftStackTests/APITests.swift
+++ b/Tests/SwiftStackTests/APITests.swift
@@ -131,7 +131,7 @@ class APITests: XCTestCase {
 			return ("{}".data(using: .utf8), self.blankResponse(task), nil)
 		}
 		
-		let _ = try client.performAPIRequest("info", ["page":"1"]) as APIResponse<Site>
+		let _ = try client.performAPIRequest("info", parameters: ["page":"1"]) as APIResponse<Site>
 	}
 	
 	
@@ -151,7 +151,7 @@ class APITests: XCTestCase {
 			return ("{}".data(using: .utf8), self.blankResponse(task), nil)
 		}
 		
-		let _ = try client.performAPIRequest("info", parameters) as APIResponse<Site>
+		let _ = try client.performAPIRequest("info", parameters: parameters) as APIResponse<Site>
 		//not actually a Site, but Info isn't implemented yet.
 	}
 	
@@ -269,7 +269,7 @@ class APITests: XCTestCase {
             return ("{\"items\": [{\"name\": \"Test Site\"}]}".data(using: .utf8), self.blankResponse(task), nil)
         }
         
-        client.fetchSites([:], backoffBehavior: .wait) {
+        client.fetchSites(parameters: [:], backoffBehavior: .wait) {
             response, error in
             if error != nil {
                 print(error!)

--- a/Tests/SwiftStackTests/BasicRequestTests.swift
+++ b/Tests/SwiftStackTests/BasicRequestTests.swift
@@ -19,7 +19,7 @@ class BasicRequestTests: XCTestCase {
 		let client = APIClient()
 		
 		let url = "https://httpbin.org/post"
-		let result = try? client.post(url, ["test":"123456"]) as String
+		let result = try? client.post(url, fields: ["test":"123456"]) as String
 		XCTAssert(result != nil)
 		
 		let json = (try? client.parseJSON(result!)) as? [String:Any]


### PR DESCRIPTION
Functions like `performAPIRequest<T>(_:_:backoffBehavior:)` did not conform to the [API Design Guidelines](https://swift.org/documentation/api-design-guidelines/#argument-labels). That's why I added the argument label for `parameters`.

The same for `post(_:_:)`. There I added `fields`.