### PR TITLE
fix floating points on 32-bit devices

### DIFF
--- a/Sources/Answer.swift
+++ b/Sources/Answer.swift
@@ -17,7 +17,7 @@ public class Answer: Post {
         
         self.accepted = dictionary["accepted"] as? Bool
         self.answer_id = dictionary["answer_id"] as? Int
-		self.post_id = answer_id
+        self.post_id = answer_id
         self.awarded_bounty_amount = dictionary["awarded_bounty_amount"] as? Int
         
         if let users = dictionary["awarded_bounty_users"] as? [[String: Any]] {
@@ -32,27 +32,27 @@ public class Answer: Post {
                 self.awarded_bounty_users = array
             }
         }
-                
+        
         if let timestamp = dictionary["community_owned_date"] as? Double {
             self.community_owned_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["community_owned_date"] as? Float {
-			self.community_owned_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["community_owned_date"] as? Float {
+            self.community_owned_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         if let timestamp = dictionary["creation_date"] as? Double {
             self.creation_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["creation_date"] as? Float {
-			self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["creation_date"] as? Float {
+            self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         self.is_accepted = dictionary["is_accepted"] as? Bool
         
         if let timestamp = dictionary["locked_date"] as? Double {
             self.locked_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["locked_date"] as? Float {
-			self.locked_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-			
+        } else if let timestamp = dictionary["locked_date"] as? Float {
+            self.locked_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         self.question_id = dictionary["question_id"] as? Int
         self.tags = dictionary["tags"] as? [String]
     }

--- a/Sources/Answer.swift
+++ b/Sources/Answer.swift
@@ -35,18 +35,24 @@ public class Answer: Post {
                 
         if let timestamp = dictionary["community_owned_date"] as? Double {
             self.community_owned_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["community_owned_date"] as? Float {
+			self.community_owned_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         if let timestamp = dictionary["creation_date"] as? Double {
             self.creation_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["creation_date"] as? Float {
+			self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         self.is_accepted = dictionary["is_accepted"] as? Bool
         
         if let timestamp = dictionary["locked_date"] as? Double {
             self.locked_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["locked_date"] as? Float {
+			self.locked_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+			
         self.question_id = dictionary["question_id"] as? Int
         self.tags = dictionary["tags"] as? [String]
     }

--- a/Sources/Comment.swift
+++ b/Sources/Comment.swift
@@ -40,10 +40,10 @@ public class Comment: Content {
         
         if let timestamp = dictionary["creation_date"] as? Double {
             self.creation_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["creation_date"] as? Float {
-			self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["creation_date"] as? Float {
+            self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         self.edited = dictionary["edited"] as? Bool
         
         if let user = dictionary["reply_to_user"] as? [String: Any] {

--- a/Sources/Comment.swift
+++ b/Sources/Comment.swift
@@ -40,8 +40,10 @@ public class Comment: Content {
         
         if let timestamp = dictionary["creation_date"] as? Double {
             self.creation_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["creation_date"] as? Float {
+			self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         self.edited = dictionary["edited"] as? Bool
         
         if let user = dictionary["reply_to_user"] as? [String: Any] {

--- a/Sources/Post.swift
+++ b/Sources/Post.swift
@@ -57,8 +57,10 @@ public class Post: Content {
             
             if let timestamp = dictionary["creation_date"] as? Double {
                 self.creation_date = Date(timeIntervalSince1970: timestamp)
-            }
-            
+			} else if let timestamp = dictionary["creation_date"] as? Float {
+				self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
+			}
+			
             self.owner_user_id = dictionary["owner_user_id"] as? Int
         }
         
@@ -131,10 +133,14 @@ public class Post: Content {
         
         if let timestamp = dictionary["last_activity_date"] as? Double {
             self.last_activity_date = Date(timeIntervalSince1970: timestamp)
+        } else if let timestamp = dictionary["last_activity_date"] as? Float {
+            self.last_activity_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
         if let timestamp = dictionary["last_edit_date"] as? Double {
             self.last_edit_date = Date(timeIntervalSince1970: timestamp)
+        } else if let timestamp = dictionary["last_edit_date"] as? Float {
+            self.last_edit_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
         if let user = dictionary["last_editor"] as? [String: Any] {

--- a/Sources/Post.swift
+++ b/Sources/Post.swift
@@ -57,10 +57,10 @@ public class Post: Content {
             
             if let timestamp = dictionary["creation_date"] as? Double {
                 self.creation_date = Date(timeIntervalSince1970: timestamp)
-			} else if let timestamp = dictionary["creation_date"] as? Float {
-				self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
-			}
-			
+            } else if let timestamp = dictionary["creation_date"] as? Float {
+                self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
+            }
+            
             self.owner_user_id = dictionary["owner_user_id"] as? Int
         }
         

--- a/Sources/Question.swift
+++ b/Sources/Question.swift
@@ -72,7 +72,7 @@ public class Question: Post {
         
         public var dictionary: [String: Any] {
             var dict = [String: Any]()
-                        
+            
             if by_users != nil && (by_users?.count)! > 0 {
                 var tmpUsers = [[String: Any]]()
                 for user in by_users! {
@@ -132,10 +132,10 @@ public class Question: Post {
         public init(dictionary: [String : Any]) {
             if let timestamp = dictionary["on_date"] as? Double {
                 self.on_date = Date(timeIntervalSince1970: timestamp)
-			} else if let timestamp = dictionary["on_date"] as? Float {
-				self.on_date = Date(timeIntervalSince1970: Double(timestamp))
-			}
-			
+            } else if let timestamp = dictionary["on_date"] as? Float {
+                self.on_date = Date(timeIntervalSince1970: Double(timestamp))
+            }
+            
             if let site = dictionary["other_site"] as? [String: Any] {
                 self.other_site = Site(dictionary: site)
             }
@@ -216,10 +216,10 @@ public class Question: Post {
         
         if let timestamp = dictionary["bounty_closes_date"] as? Double {
             self.bounty_closes_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["bounty_closes_date"] as? Float {
-			self.bounty_closes_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["bounty_closes_date"] as? Float {
+            self.bounty_closes_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         if let user = dictionary["bounty_user"] as? [String: Any] {
             self.bounty_user = User(dictionary: user)
         }
@@ -229,10 +229,10 @@ public class Question: Post {
         
         if let timestamp = dictionary["closed_date"] as? Double {
             self.closed_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["closed_date"] as? Float {
-			self.closed_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["closed_date"] as? Float {
+            self.closed_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         if let closedDetailsDict = dictionary["closed_details"] as? [String: Any] {
             self.closed_details = ClosedDetails(dictionary: closedDetailsDict)
         }
@@ -242,16 +242,16 @@ public class Question: Post {
         
         if let timestamp = dictionary["community_owned_date"] as? Double {
             self.community_owned_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["community_owned_date"] as? Float {
-			self.community_owned_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["community_owned_date"] as? Float {
+            self.community_owned_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         if let timestamp = dictionary["creation_date"] as? Double {
             self.creation_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["creation_date"] as? Float {
-			self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["creation_date"] as? Float {
+            self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         self.delete_vote_count = dictionary["delete_vote_count"] as? Int
         self.favorite_count = dictionary["favorite_count"] as? Int
         self.favorited = dictionary["favorites"] as? Bool
@@ -259,10 +259,10 @@ public class Question: Post {
         
         if let timestamp = dictionary["locked_date"] as? Double {
             self.locked_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["locked_date"] as? Float {
-			self.locked_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["locked_date"] as? Float {
+            self.locked_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         if let migration = dictionary["migrated_from"] as? [String: Any] {
             self.migrated_from = MigrationInfo(dictionary: migration)
         }
@@ -270,19 +270,19 @@ public class Question: Post {
         if let migration = dictionary["migrated_to"] as? [String: Any] {
             self.migrated_to = MigrationInfo(dictionary: migration)
         }
-                
+        
         if let noticeArray = dictionary["notice"] as? [String: Any] {
             self.notice = Notice(dictionary: noticeArray)
         }
         
         if let timestamp = dictionary["protected_date"] as? Double {
             self.protected_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["protected_date"] as? Float {
-			self.protected_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["protected_date"] as? Float {
+            self.protected_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         self.question_id = dictionary["question_id"] as? Int
-		self.post_id = question_id
+        self.post_id = question_id
         self.reopen_vote_count = dictionary["reopen_vote_count"] as? Int
         self.tags = dictionary["tags"] as? [String]
         

--- a/Sources/Question.swift
+++ b/Sources/Question.swift
@@ -132,8 +132,10 @@ public class Question: Post {
         public init(dictionary: [String : Any]) {
             if let timestamp = dictionary["on_date"] as? Double {
                 self.on_date = Date(timeIntervalSince1970: timestamp)
-            }
-            
+			} else if let timestamp = dictionary["on_date"] as? Float {
+				self.on_date = Date(timeIntervalSince1970: Double(timestamp))
+			}
+			
             if let site = dictionary["other_site"] as? [String: Any] {
                 self.other_site = Site(dictionary: site)
             }
@@ -214,8 +216,10 @@ public class Question: Post {
         
         if let timestamp = dictionary["bounty_closes_date"] as? Double {
             self.bounty_closes_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["bounty_closes_date"] as? Float {
+			self.bounty_closes_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         if let user = dictionary["bounty_user"] as? [String: Any] {
             self.bounty_user = User(dictionary: user)
         }
@@ -225,8 +229,10 @@ public class Question: Post {
         
         if let timestamp = dictionary["closed_date"] as? Double {
             self.closed_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["closed_date"] as? Float {
+			self.closed_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         if let closedDetailsDict = dictionary["closed_details"] as? [String: Any] {
             self.closed_details = ClosedDetails(dictionary: closedDetailsDict)
         }
@@ -236,12 +242,16 @@ public class Question: Post {
         
         if let timestamp = dictionary["community_owned_date"] as? Double {
             self.community_owned_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["community_owned_date"] as? Float {
+			self.community_owned_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         if let timestamp = dictionary["creation_date"] as? Double {
             self.creation_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["creation_date"] as? Float {
+			self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         self.delete_vote_count = dictionary["delete_vote_count"] as? Int
         self.favorite_count = dictionary["favorite_count"] as? Int
         self.favorited = dictionary["favorites"] as? Bool
@@ -249,8 +259,10 @@ public class Question: Post {
         
         if let timestamp = dictionary["locked_date"] as? Double {
             self.locked_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["locked_date"] as? Float {
+			self.locked_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         if let migration = dictionary["migrated_from"] as? [String: Any] {
             self.migrated_from = MigrationInfo(dictionary: migration)
         }
@@ -265,8 +277,10 @@ public class Question: Post {
         
         if let timestamp = dictionary["protected_date"] as? Double {
             self.protected_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["protected_date"] as? Float {
+			self.protected_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         self.question_id = dictionary["question_id"] as? Int
 		self.post_id = question_id
         self.reopen_vote_count = dictionary["reopen_vote_count"] as? Int

--- a/Sources/Site.swift
+++ b/Sources/Site.swift
@@ -214,10 +214,10 @@ public class Site: JsonConvertible, CustomStringConvertible {
         
         if let timestamp = dictionary["closed_beta_date"] as? Double {
             self.closed_beta_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["closed_beta_date"] as? Float {
-			self.closed_beta_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["closed_beta_date"] as? Float {
+            self.closed_beta_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         if let url = dictionary["favicon_url"] as? String {
             self.favicon_url = URL(string: url)
         }
@@ -243,10 +243,10 @@ public class Site: JsonConvertible, CustomStringConvertible {
         
         if let timestamp = dictionary["open_beta_date"] as? Double {
             self.open_beta_date = Date(timeIntervalSince1970: timestamp)
-		} else if let timestamp = dictionary["open_beta_date"] as? Float {
-			self.open_beta_date = Date(timeIntervalSince1970: Double(timestamp))
-		}
-		
+        } else if let timestamp = dictionary["open_beta_date"] as? Float {
+            self.open_beta_date = Date(timeIntervalSince1970: Double(timestamp))
+        }
+        
         if let relatedSites = dictionary["related_sites"] as? [[String: Any]] {
             var relatedArray = [Related]()
             

--- a/Sources/Site.swift
+++ b/Sources/Site.swift
@@ -214,8 +214,10 @@ public class Site: JsonConvertible, CustomStringConvertible {
         
         if let timestamp = dictionary["closed_beta_date"] as? Double {
             self.closed_beta_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["closed_beta_date"] as? Float {
+			self.closed_beta_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         if let url = dictionary["favicon_url"] as? String {
             self.favicon_url = URL(string: url)
         }
@@ -241,8 +243,10 @@ public class Site: JsonConvertible, CustomStringConvertible {
         
         if let timestamp = dictionary["open_beta_date"] as? Double {
             self.open_beta_date = Date(timeIntervalSince1970: timestamp)
-        }
-        
+		} else if let timestamp = dictionary["open_beta_date"] as? Float {
+			self.open_beta_date = Date(timeIntervalSince1970: Double(timestamp))
+		}
+		
         if let relatedSites = dictionary["related_sites"] as? [[String: Any]] {
             var relatedArray = [Related]()
             

--- a/Sources/User.swift
+++ b/Sources/User.swift
@@ -9,274 +9,274 @@
 import Foundation
 
 /**
- Represents a user on StackExchange.
- 
- - author: FelixSFD
- 
- - seealso: [StackExchange API](https://api.stackexchange.com/docs/types/user)
- */
+Represents a user on StackExchange.
+
+- author: FelixSFD
+
+- seealso: [StackExchange API](https://api.stackexchange.com/docs/types/user)
+*/
 public class User: JsonConvertible, CustomStringConvertible {
-    
-    // - MARK: The user-type
-    
-    /**
-     The tpye of the user. The StackExchange API returns different types of users depending on the use-case.
-     
-     - author: FelixSFD
-     */
-    public enum UserInfoType: String {
-        /**
-         This user-type can contain all available properties
-         */
-        case full = "full_user"
-        case shallow = "shallow_user"
-        case network = "network_user"
-        
-        /**
-         This user-type could contain anything, but most likely, it is not initialized correctly.
-         */
-        case undefined = "undefined"
-        
-        /**
-         Initializes the enum with `.undefined` as default value.
-         */
-        public init() {
-            self = .undefined
-        }
-    }
-    
-    /**
-     The type of the user/account as returned form the API.
-     
-     - author: FelixSFD
-     
-     - seealso: [StackExchange API](https://api.stackexchange.com/docs/types/user)
-     */
-    public enum UserType: String, StringRepresentable {
-        case unregistered = "unregistered"
-        case registered = "registered"
-        case moderator = "moderator"
-        case doesNotExist = "does_not_exist"
-    }
-    
-    // - MARK: Public properties
-    
-    /**
-     The `User.UserType` of the user.
-     
-     This does not affect the other properties. It's just for the developers to see, which data they can expect.
-     */
-    public var type = User.UserInfoType.undefined
-    
-    
-    // - MARK: Initializers
-    
-    /**
-     Simple initializer with an `UserInfoType` as possible parameter.
-     
-     - parameter type: The `UserType` the new instance should have
-     
-     - author: FelixSFD
-     */
-    public init(type: UserInfoType) {
-        self.type = type
-    }
-    
-    /**
-     Initializes the object from a JSON string.
-     
-     - parameter json: The JSON string returned by the API
-     
-     - author: FelixSFD
-     */
-    public convenience required init?(jsonString json: String) {
-        do {
-            guard let dictionary = try JSONSerialization.jsonObject(with: json.data(using: String.Encoding.utf8)!, options: .allowFragments) as? [String: Any] else {
-                return nil
-            }
-            
-            self.init(dictionary: dictionary)
-        } catch {
-            return nil
-        }
-    }
-    
-    public required init(dictionary: [String: Any]) {
-        self.about_me = dictionary["about_me"] as? String
-        self.accept_rate = dictionary["accept_rate"] as? Int
-        self.account_id = dictionary["account_id"] as? Int
-        self.age = dictionary["age"] as? Int
-        self.answer_count = dictionary["answer_count"] as? Int
-        
-        if let badgeCounts = dictionary["badge_counts"] as? [String: Any] {
-            self.badge_counts = BadgeCount(dictionary: badgeCounts)
-        }
-        
-        if let creationTimestamp = dictionary["creation_date"] as? Double {
-            self.creation_date = Date(timeIntervalSince1970: creationTimestamp)
+	
+	// - MARK: The user-type
+	
+	/**
+	The tpye of the user. The StackExchange API returns different types of users depending on the use-case.
+	
+	- author: FelixSFD
+	*/
+	public enum UserInfoType: String {
+		/**
+		This user-type can contain all available properties
+		*/
+		case full = "full_user"
+		case shallow = "shallow_user"
+		case network = "network_user"
+		
+		/**
+		This user-type could contain anything, but most likely, it is not initialized correctly.
+		*/
+		case undefined = "undefined"
+		
+		/**
+		Initializes the enum with `.undefined` as default value.
+		*/
+		public init() {
+			self = .undefined
+		}
+	}
+	
+	/**
+	The type of the user/account as returned form the API.
+	
+	- author: FelixSFD
+	
+	- seealso: [StackExchange API](https://api.stackexchange.com/docs/types/user)
+	*/
+	public enum UserType: String, StringRepresentable {
+		case unregistered = "unregistered"
+		case registered = "registered"
+		case moderator = "moderator"
+		case doesNotExist = "does_not_exist"
+	}
+	
+	// - MARK: Public properties
+	
+	/**
+	The `User.UserType` of the user.
+	
+	This does not affect the other properties. It's just for the developers to see, which data they can expect.
+	*/
+	public var type = User.UserInfoType.undefined
+	
+	
+	// - MARK: Initializers
+	
+	/**
+	Simple initializer with an `UserInfoType` as possible parameter.
+	
+	- parameter type: The `UserType` the new instance should have
+	
+	- author: FelixSFD
+	*/
+	public init(type: UserInfoType) {
+		self.type = type
+	}
+	
+	/**
+	Initializes the object from a JSON string.
+	
+	- parameter json: The JSON string returned by the API
+	
+	- author: FelixSFD
+	*/
+	public convenience required init?(jsonString json: String) {
+		do {
+			guard let dictionary = try JSONSerialization.jsonObject(with: json.data(using: String.Encoding.utf8)!, options: .allowFragments) as? [String: Any] else {
+				return nil
+			}
+			
+			self.init(dictionary: dictionary)
+		} catch {
+			return nil
+		}
+	}
+	
+	public required init(dictionary: [String: Any]) {
+		self.about_me = dictionary["about_me"] as? String
+		self.accept_rate = dictionary["accept_rate"] as? Int
+		self.account_id = dictionary["account_id"] as? Int
+		self.age = dictionary["age"] as? Int
+		self.answer_count = dictionary["answer_count"] as? Int
+		
+		if let badgeCounts = dictionary["badge_counts"] as? [String: Any] {
+			self.badge_counts = BadgeCount(dictionary: badgeCounts)
+		}
+		
+		if let creationTimestamp = dictionary["creation_date"] as? Double {
+			self.creation_date = Date(timeIntervalSince1970: creationTimestamp)
 		} else if let creationTimestamp = dictionary["creation_date"] as? Float {
 			self.creation_date = Date(timeIntervalSince1970: Double(creationTimestamp))
 		}
 		
-        self.display_name = dictionary["display_name"] as? String
-        self.down_vote_count = dictionary["down_vote_count"] as? Int
-        self.is_employee = dictionary["is_employee"] as? Bool
-        
-        if let lastAccessTimestamp = dictionary["last_access_date"] as? Double {
-            self.last_access_date = Date(timeIntervalSince1970: lastAccessTimestamp)
+		self.display_name = dictionary["display_name"] as? String
+		self.down_vote_count = dictionary["down_vote_count"] as? Int
+		self.is_employee = dictionary["is_employee"] as? Bool
+		
+		if let lastAccessTimestamp = dictionary["last_access_date"] as? Double {
+			self.last_access_date = Date(timeIntervalSince1970: lastAccessTimestamp)
 		} else if let lastAccessTimestamp = dictionary["last_access_date"] as? Float {
 			self.last_access_date = Date(timeIntervalSince1970: Double(lastAccessTimestamp))
 		}
 		
-        if let lastModifiedTimestamp = dictionary["last_modified_date"] as? Double {
-            self.last_modified_date = Date(timeIntervalSince1970: lastModifiedTimestamp)
+		if let lastModifiedTimestamp = dictionary["last_modified_date"] as? Double {
+			self.last_modified_date = Date(timeIntervalSince1970: lastModifiedTimestamp)
 		} else if let lastModifiedTimestamp = dictionary["last_modified_date"] as? Float {
 			self.last_modified_date = Date(timeIntervalSince1970: Double(lastModifiedTimestamp))
 		}
 		
-        if let urlString = dictionary["link"] as? String {
-            self.link = URL(string: urlString)
-        }
-        
-        self.location = dictionary["location"] as? String
-        
-        if let urlString = dictionary["profile_image"] as? String {
-            self.link = URL(string: urlString)
-        }
-        
-        self.question_count = dictionary["question_count"] as? Int
-        self.reputation = dictionary["reputation"] as? Int
-        self.reputation_change_day = dictionary["reputation_change_day"] as? Int
-        self.reputation_change_week = dictionary["reputation_change_week"] as? Int
-        self.reputation_change_month = dictionary["reputation_change_month"] as? Int
-        self.reputation_change_quarter = dictionary["reputation_change_quarter"] as? Int
-        self.reputation_change_year = dictionary["reputation_change_year"] as? Int
-        
-        if let timedPenaltyTimestamp = dictionary["timed_penalty_date"] as? Double {
-            self.timed_penalty_date = Date(timeIntervalSince1970: timedPenaltyTimestamp)
+		if let urlString = dictionary["link"] as? String {
+			self.link = URL(string: urlString)
+		}
+		
+		self.location = dictionary["location"] as? String
+		
+		if let urlString = dictionary["profile_image"] as? String {
+			self.link = URL(string: urlString)
+		}
+		
+		self.question_count = dictionary["question_count"] as? Int
+		self.reputation = dictionary["reputation"] as? Int
+		self.reputation_change_day = dictionary["reputation_change_day"] as? Int
+		self.reputation_change_week = dictionary["reputation_change_week"] as? Int
+		self.reputation_change_month = dictionary["reputation_change_month"] as? Int
+		self.reputation_change_quarter = dictionary["reputation_change_quarter"] as? Int
+		self.reputation_change_year = dictionary["reputation_change_year"] as? Int
+		
+		if let timedPenaltyTimestamp = dictionary["timed_penalty_date"] as? Double {
+			self.timed_penalty_date = Date(timeIntervalSince1970: timedPenaltyTimestamp)
 		} else if let timedPenaltyTimestamp = dictionary["timed_penalty_date"] as? Float {
 			self.timed_penalty_date = Date(timeIntervalSince1970: Double(timedPenaltyTimestamp))
 		}
 		
-        self.up_vote_count = dictionary["up_vote_count"] as? Int
-        self.user_id = dictionary["user_id"] as? Int
-        
-        if let userTypeString = dictionary["user_type"] as? String {
-            self.user_type = UserType(rawValue: userTypeString)
-        }
-        
-        self.view_count = dictionary["view_count"] as? Int
-        self.website_url = dictionary["website_url"] as? String
-    }
-    
-    /**
-     Basic initializer without any parameters
-     */
-    public init() { }
-    
-    // - MARK: JsonConvertible
-    
-    public var dictionary: [String: Any] {
-        var dict = [String: Any]()
-        
-        dict["about_me"] = about_me
-        dict["accept_rate"] = accept_rate
-        dict["account_id"] = account_id
-        dict["age"] = age
-        dict["answer_count"] = answer_count
-        dict["badge_counts"] = badge_counts?.dictionary
-        dict["creation_date"] = creation_date
-        dict["display_name"] = display_name
-        dict["down_vote_count"] = down_vote_count
-        dict["is_employee"] = is_employee
-        dict["last_access_date"] = last_access_date
-        dict["last_modified_date"] = last_modified_date
-        dict["link"] = link
-        dict["location"] = location
-        dict["profile_image"] = profile_image
-        dict["question_count"] = question_count
-        dict["reputation"] = reputation
-        dict["reputation_change_day"] = reputation_change_day
-        dict["reputation_change_week"] = reputation_change_week
-        dict["reputation_change_month"] = reputation_change_month
-        dict["reputation_change_quarter"] = reputation_change_quarter
-        dict["reputation_change_year"] = reputation_change_year
-        dict["timed_penalty_date"] = timed_penalty_date
-        dict["up_vote_count"] = up_vote_count
-        dict["user_id"] = user_id
-        dict["user_type"] = user_type
-        dict["view_count"] = view_count
-        dict["website_url"] = website_url
-        
-        return dict
-    }
-    
-    public var jsonString: String? {
-        return (try? JsonHelper.jsonString(from: self)) ?? nil
-    }
-    
-    // - MARK: CustomStringConvertible
-    
-    public var description: String {
-        return "\(dictionary)"
-    }
-    
-    // - MARK: Values returned from API
-    
-    public var about_me: String?
-    
-    public var accept_rate: Int?
-    
-    public var account_id: Int?
-    
-    public var age: Int?
-    
-    public var answer_count: Int?
-    
-    public var badge_counts: BadgeCount?
-    
-    public var creation_date: Date?
-    
-    public var display_name: String?
-    
-    public var down_vote_count: Int?
-    
-    public var is_employee: Bool?
-    
-    public var last_access_date: Date?
-    
-    public var last_modified_date: Date?
-    
-    public var link: URL?
-    
-    public var location: String?
-    
-    public var profile_image: URL?
-    
-    public var question_count: Int?
-    
-    public var reputation: Int?
-    
-    public var reputation_change_day: Int?
-    
-    public var reputation_change_month: Int?
-    
-    public var reputation_change_quarter: Int?
-    
-    public var reputation_change_week: Int?
-    
-    public var reputation_change_year: Int?
-    
-    public var timed_penalty_date: Date?
-    
-    public var up_vote_count: Int?
-    
-    public var user_id: Int?
-    
-    public var user_type: UserType?
-    
-    public var view_count: Int?
-    
-    public var website_url: String?
-    
+		self.up_vote_count = dictionary["up_vote_count"] as? Int
+		self.user_id = dictionary["user_id"] as? Int
+		
+		if let userTypeString = dictionary["user_type"] as? String {
+			self.user_type = UserType(rawValue: userTypeString)
+		}
+		
+		self.view_count = dictionary["view_count"] as? Int
+		self.website_url = dictionary["website_url"] as? String
+	}
+	
+	/**
+	Basic initializer without any parameters
+	*/
+	public init() { }
+	
+	// - MARK: JsonConvertible
+	
+	public var dictionary: [String: Any] {
+		var dict = [String: Any]()
+		
+		dict["about_me"] = about_me
+		dict["accept_rate"] = accept_rate
+		dict["account_id"] = account_id
+		dict["age"] = age
+		dict["answer_count"] = answer_count
+		dict["badge_counts"] = badge_counts?.dictionary
+		dict["creation_date"] = creation_date
+		dict["display_name"] = display_name
+		dict["down_vote_count"] = down_vote_count
+		dict["is_employee"] = is_employee
+		dict["last_access_date"] = last_access_date
+		dict["last_modified_date"] = last_modified_date
+		dict["link"] = link
+		dict["location"] = location
+		dict["profile_image"] = profile_image
+		dict["question_count"] = question_count
+		dict["reputation"] = reputation
+		dict["reputation_change_day"] = reputation_change_day
+		dict["reputation_change_week"] = reputation_change_week
+		dict["reputation_change_month"] = reputation_change_month
+		dict["reputation_change_quarter"] = reputation_change_quarter
+		dict["reputation_change_year"] = reputation_change_year
+		dict["timed_penalty_date"] = timed_penalty_date
+		dict["up_vote_count"] = up_vote_count
+		dict["user_id"] = user_id
+		dict["user_type"] = user_type
+		dict["view_count"] = view_count
+		dict["website_url"] = website_url
+		
+		return dict
+	}
+	
+	public var jsonString: String? {
+		return (try? JsonHelper.jsonString(from: self)) ?? nil
+	}
+	
+	// - MARK: CustomStringConvertible
+	
+	public var description: String {
+		return "\(dictionary)"
+	}
+	
+	// - MARK: Values returned from API
+	
+	public var about_me: String?
+	
+	public var accept_rate: Int?
+	
+	public var account_id: Int?
+	
+	public var age: Int?
+	
+	public var answer_count: Int?
+	
+	public var badge_counts: BadgeCount?
+	
+	public var creation_date: Date?
+	
+	public var display_name: String?
+	
+	public var down_vote_count: Int?
+	
+	public var is_employee: Bool?
+	
+	public var last_access_date: Date?
+	
+	public var last_modified_date: Date?
+	
+	public var link: URL?
+	
+	public var location: String?
+	
+	public var profile_image: URL?
+	
+	public var question_count: Int?
+	
+	public var reputation: Int?
+	
+	public var reputation_change_day: Int?
+	
+	public var reputation_change_month: Int?
+	
+	public var reputation_change_quarter: Int?
+	
+	public var reputation_change_week: Int?
+	
+	public var reputation_change_year: Int?
+	
+	public var timed_penalty_date: Date?
+	
+	public var up_vote_count: Int?
+	
+	public var user_id: Int?
+	
+	public var user_type: UserType?
+	
+	public var view_count: Int?
+	
+	public var website_url: String?
+	
 }

--- a/Sources/User.swift
+++ b/Sources/User.swift
@@ -114,20 +114,26 @@ public class User: JsonConvertible, CustomStringConvertible {
         
         if let creationTimestamp = dictionary["creation_date"] as? Double {
             self.creation_date = Date(timeIntervalSince1970: creationTimestamp)
-        }
-        
+		} else if let creationTimestamp = dictionary["creation_date"] as? Float {
+			self.creation_date = Date(timeIntervalSince1970: Double(creationTimestamp))
+		}
+		
         self.display_name = dictionary["display_name"] as? String
         self.down_vote_count = dictionary["down_vote_count"] as? Int
         self.is_employee = dictionary["is_employee"] as? Bool
         
         if let lastAccessTimestamp = dictionary["last_access_date"] as? Double {
             self.last_access_date = Date(timeIntervalSince1970: lastAccessTimestamp)
-        }
-        
+		} else if let lastAccessTimestamp = dictionary["last_access_date"] as? Float {
+			self.last_access_date = Date(timeIntervalSince1970: Double(lastAccessTimestamp))
+		}
+		
         if let lastModifiedTimestamp = dictionary["last_modified_date"] as? Double {
             self.last_modified_date = Date(timeIntervalSince1970: lastModifiedTimestamp)
-        }
-        
+		} else if let lastModifiedTimestamp = dictionary["last_modified_date"] as? Float {
+			self.last_modified_date = Date(timeIntervalSince1970: Double(lastModifiedTimestamp))
+		}
+		
         if let urlString = dictionary["link"] as? String {
             self.link = URL(string: urlString)
         }
@@ -148,8 +154,10 @@ public class User: JsonConvertible, CustomStringConvertible {
         
         if let timedPenaltyTimestamp = dictionary["timed_penalty_date"] as? Double {
             self.timed_penalty_date = Date(timeIntervalSince1970: timedPenaltyTimestamp)
-        }
-        
+		} else if let timedPenaltyTimestamp = dictionary["timed_penalty_date"] as? Float {
+			self.timed_penalty_date = Date(timeIntervalSince1970: Double(timedPenaltyTimestamp))
+		}
+		
         self.up_vote_count = dictionary["up_vote_count"] as? Int
         self.user_id = dictionary["user_id"] as? Int
         


### PR DESCRIPTION
`Double` was used everywhere for floating point types because that's the type `JSONSerialization` returns on 64-bit devices.  However, on 32-bit devices, `Float` is returned instead.  I added checks for `Float`s everywhere we extracted floating-point types from JSON.  There might be a better way to do this, but I didn't think of one.