### PR TITLE
fix date handling on Linux

### DIFF
--- a/Sources/Answer.swift
+++ b/Sources/Answer.swift
@@ -33,23 +33,17 @@ public class Answer: Post {
             }
         }
         
-        if let timestamp = dictionary["community_owned_date"] as? Double {
-            self.community_owned_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["community_owned_date"] as? Float {
+        if let timestamp = dictionary["community_owned_date"] as? Int {
             self.community_owned_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
-        if let timestamp = dictionary["creation_date"] as? Double {
-            self.creation_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["creation_date"] as? Float {
+        if let timestamp = dictionary["creation_date"] as? Int {
             self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
         self.is_accepted = dictionary["is_accepted"] as? Bool
         
-        if let timestamp = dictionary["locked_date"] as? Double {
-            self.locked_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["locked_date"] as? Float {
+        if let timestamp = dictionary["locked_date"] as? Int {
             self.locked_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         

--- a/Sources/Comment.swift
+++ b/Sources/Comment.swift
@@ -38,9 +38,7 @@ public class Comment: Content {
         
         self.comment_id = dictionary["comment_id"] as? Int
         
-        if let timestamp = dictionary["creation_date"] as? Double {
-            self.creation_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["creation_date"] as? Float {
+        if let timestamp = dictionary["creation_date"] as? Int {
             self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         

--- a/Sources/Post.swift
+++ b/Sources/Post.swift
@@ -55,9 +55,7 @@ public class Post: Content {
         public init(dictionary: [String: Any]) {
             self.body = dictionary["body"] as? String
             
-            if let timestamp = dictionary["creation_date"] as? Double {
-                self.creation_date = Date(timeIntervalSince1970: timestamp)
-            } else if let timestamp = dictionary["creation_date"] as? Float {
+            if let timestamp = dictionary["creation_date"] as? Int {
                 self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
             }
             
@@ -131,15 +129,11 @@ public class Post: Content {
         self.down_vote_count = dictionary["down_vote_count"] as? Int
         self.downvoted = dictionary["downvoted"] as? Bool
         
-        if let timestamp = dictionary["last_activity_date"] as? Double {
-            self.last_activity_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["last_activity_date"] as? Float {
+        if let timestamp = dictionary["last_activity_date"] as? Int {
             self.last_activity_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
-        if let timestamp = dictionary["last_edit_date"] as? Double {
-            self.last_edit_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["last_edit_date"] as? Float {
+        if let timestamp = dictionary["last_edit_date"] as? Int {
             self.last_edit_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         

--- a/Sources/Question.swift
+++ b/Sources/Question.swift
@@ -130,9 +130,7 @@ public class Question: Post {
         }
         
         public init(dictionary: [String : Any]) {
-            if let timestamp = dictionary["on_date"] as? Double {
-                self.on_date = Date(timeIntervalSince1970: timestamp)
-            } else if let timestamp = dictionary["on_date"] as? Float {
+            if let timestamp = dictionary["on_date"] as? Int {
                 self.on_date = Date(timeIntervalSince1970: Double(timestamp))
             }
             
@@ -214,9 +212,7 @@ public class Question: Post {
         
         self.bounty_amount = dictionary["bounty_amount"] as? Int
         
-        if let timestamp = dictionary["bounty_closes_date"] as? Double {
-            self.bounty_closes_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["bounty_closes_date"] as? Float {
+        if let timestamp = dictionary["bounty_closes_date"] as? Int {
             self.bounty_closes_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
@@ -227,9 +223,7 @@ public class Question: Post {
         self.can_close = dictionary["can_close"] as? Bool
         self.close_vote_count = dictionary["close_vote_count"] as? Int
         
-        if let timestamp = dictionary["closed_date"] as? Double {
-            self.closed_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["closed_date"] as? Float {
+        if let timestamp = dictionary["closed_date"] as? Int {
             self.closed_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
@@ -240,15 +234,11 @@ public class Question: Post {
         
         self.closed_reason = dictionary["closed_reason"] as? String
         
-        if let timestamp = dictionary["community_owned_date"] as? Double {
-            self.community_owned_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["community_owned_date"] as? Float {
+        if let timestamp = dictionary["community_owned_date"] as? Int {
             self.community_owned_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
-        if let timestamp = dictionary["creation_date"] as? Double {
-            self.creation_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["creation_date"] as? Float {
+        if let timestamp = dictionary["creation_date"] as? Int {
             self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
@@ -257,9 +247,7 @@ public class Question: Post {
         self.favorited = dictionary["favorites"] as? Bool
         self.is_answered = dictionary["is_answered"] as? Bool
         
-        if let timestamp = dictionary["locked_date"] as? Double {
-            self.locked_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["locked_date"] as? Float {
+        if let timestamp = dictionary["locked_date"] as? Int {
             self.locked_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
@@ -275,9 +263,7 @@ public class Question: Post {
             self.notice = Notice(dictionary: noticeArray)
         }
         
-        if let timestamp = dictionary["protected_date"] as? Double {
-            self.protected_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["protected_date"] as? Float {
+        if let timestamp = dictionary["protected_date"] as? Int {
             self.protected_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         

--- a/Sources/Site.swift
+++ b/Sources/Site.swift
@@ -212,9 +212,7 @@ public class Site: JsonConvertible, CustomStringConvertible {
         self.api_site_parameter = dictionary["api_site_parameter"] as? String
         self.audience = dictionary["audience"] as? String
         
-        if let timestamp = dictionary["closed_beta_date"] as? Double {
-            self.closed_beta_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["closed_beta_date"] as? Float {
+        if let timestamp = dictionary["closed_beta_date"] as? Int {
             self.closed_beta_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         
@@ -241,9 +239,7 @@ public class Site: JsonConvertible, CustomStringConvertible {
         self.markdown_extensions = dictionary["markdown_extensions"] as? [String]
         self.name = dictionary["name"] as? String
         
-        if let timestamp = dictionary["open_beta_date"] as? Double {
-            self.open_beta_date = Date(timeIntervalSince1970: timestamp)
-        } else if let timestamp = dictionary["open_beta_date"] as? Float {
+        if let timestamp = dictionary["open_beta_date"] as? Int {
             self.open_beta_date = Date(timeIntervalSince1970: Double(timestamp))
         }
         

--- a/Sources/User.swift
+++ b/Sources/User.swift
@@ -112,9 +112,7 @@ public class User: JsonConvertible, CustomStringConvertible {
 			self.badge_counts = BadgeCount(dictionary: badgeCounts)
 		}
 		
-		if let creationTimestamp = dictionary["creation_date"] as? Double {
-			self.creation_date = Date(timeIntervalSince1970: creationTimestamp)
-		} else if let creationTimestamp = dictionary["creation_date"] as? Float {
+		if let creationTimestamp = dictionary["creation_date"] as? Int {
 			self.creation_date = Date(timeIntervalSince1970: Double(creationTimestamp))
 		}
 		
@@ -122,15 +120,11 @@ public class User: JsonConvertible, CustomStringConvertible {
 		self.down_vote_count = dictionary["down_vote_count"] as? Int
 		self.is_employee = dictionary["is_employee"] as? Bool
 		
-		if let lastAccessTimestamp = dictionary["last_access_date"] as? Double {
-			self.last_access_date = Date(timeIntervalSince1970: lastAccessTimestamp)
-		} else if let lastAccessTimestamp = dictionary["last_access_date"] as? Float {
+		if let lastAccessTimestamp = dictionary["last_access_date"] as? Int {
 			self.last_access_date = Date(timeIntervalSince1970: Double(lastAccessTimestamp))
 		}
 		
-		if let lastModifiedTimestamp = dictionary["last_modified_date"] as? Double {
-			self.last_modified_date = Date(timeIntervalSince1970: lastModifiedTimestamp)
-		} else if let lastModifiedTimestamp = dictionary["last_modified_date"] as? Float {
+		if let lastModifiedTimestamp = dictionary["last_modified_date"] as? Int {
 			self.last_modified_date = Date(timeIntervalSince1970: Double(lastModifiedTimestamp))
 		}
 		
@@ -152,9 +146,7 @@ public class User: JsonConvertible, CustomStringConvertible {
 		self.reputation_change_quarter = dictionary["reputation_change_quarter"] as? Int
 		self.reputation_change_year = dictionary["reputation_change_year"] as? Int
 		
-		if let timedPenaltyTimestamp = dictionary["timed_penalty_date"] as? Double {
-			self.timed_penalty_date = Date(timeIntervalSince1970: timedPenaltyTimestamp)
-		} else if let timedPenaltyTimestamp = dictionary["timed_penalty_date"] as? Float {
+		if let timedPenaltyTimestamp = dictionary["timed_penalty_date"] as? Int {
 			self.timed_penalty_date = Date(timeIntervalSince1970: Double(timedPenaltyTimestamp))
 		}
 		


### PR DESCRIPTION
Well, #12 didn't work.  What's *actually* going on is that the API returns dates as integers.  On macOS, Swift was able to implicitly convert, but not on Linux.