### PR TITLE
Feature/more question requests

### DIFF
--- a/Sources/Question.swift
+++ b/Sources/Question.swift
@@ -168,6 +168,148 @@ public class Question: Post {
     }
     
     
+    // - MARK: Question Timeline
+    
+    /**
+     This type represents events in the history of a `Question`.
+     
+     - author: FelixSFD
+     */
+    public class Timeline: JsonConvertible {
+        
+        // - MARK: Timeline Type
+        
+        /**
+         The type of the timeline-event
+         
+         - author: FelixSFD
+         */
+        public enum TimelineType: String, StringRepresentable {
+            ////One of the answers was marked as "accepted"
+            case accepted_answer = "accepted_answer"
+            
+            ////An `Answer` was posted
+            case answer = "answer"
+            
+            ////A `Comment` was posted
+            case comment = "comment"
+            
+            ////The state of the post changed
+            case post_state_changed = "post_state_changed"
+            
+            ////The `Question` was asked
+            case question = "question"
+            
+            ////A post was modified
+            case revision = "revision"
+            
+            ////The accpeted answer was marked as "unaccepted"
+            case unaccepted_answer = "unaccepted_answer"
+            
+            ////???
+            case vote_aggregate = "vote_aggregate"
+        }
+        
+        
+        /**
+         Initializes the object from a JSON string.
+         
+         - parameter json: The JSON string returned by the API
+         
+         - author: FelixSFD
+         */
+        public required convenience init?(jsonString json: String) {
+            do {
+                guard let dictionary = try JSONSerialization.jsonObject(with: json.data(using: String.Encoding.utf8)!, options: .allowFragments) as? [String: Any] else {
+                    return nil
+                }
+                
+                self.init(dictionary: dictionary)
+            } catch {
+                return nil
+            }
+        }
+        
+        public required init(dictionary: [String: Any]) {
+            self.comment_id = dictionary["comment_id"] as? Int
+            
+            if let timestamp = dictionary["creation_date"] as? Int {
+                self.creation_date = Date(timeIntervalSince1970: Double(timestamp))
+            }
+            
+            self.down_vote_count = dictionary["down_vote_count"] as? Int
+            
+            if let user = dictionary["owner"] as? [String: Any] {
+                self.owner = User(dictionary: user)
+            }
+            
+            self.post_id = dictionary["post_id"] as? Int
+            self.question_id = dictionary["question_id"] as? Int
+            
+            self.revision_guid = dictionary["revision_quid"] as? String
+            
+            if let type = dictionary["timeline_type"] as? String {
+                self.timeline_type = TimelineType(rawValue: type)
+            }
+            
+            self.up_vote_count = dictionary["up_vote_count"] as? Int
+            
+            if let user = dictionary["user"] as? [String: Any] {
+                self.user = User(dictionary: user)
+            }
+        }
+        
+        
+        // - MARK: JsonConvertible
+        
+        public var dictionary: [String: Any] {
+            var dict = [String: Any]()
+            
+            dict["comment_id"] = comment_id
+            dict["creation_date"] = creation_date
+            dict["down_vote_count"] = down_vote_count
+            dict["owner"] = owner?.dictionary
+            dict["post_id"] = post_id
+            dict["question_id"] = question_id
+            dict["revision_guid"] = revision_guid
+            dict["timeline_type"] = timeline_type
+            dict["up_vote_count"] = up_vote_count
+            dict["user"] = user?.dictionary
+            
+            
+            return dict
+        }
+        
+        public var jsonString: String? {
+            return (try? JsonHelper.jsonString(from: self)) ?? nil
+        }
+        
+        
+        // - MARK: Fields
+        
+        public var comment_id: Int?
+        
+        public var creation_date: Date?
+        
+        public var down_vote_count: Int?
+        
+        public var owner: User?
+        
+        public var post_id: Int?
+        
+        public var question_id: Int?
+        
+        public var revision_guid: String?
+        
+        public var timeline_type: TimelineType?
+        
+        public var up_vote_count: Int?
+        
+        public var user: User?
+        
+    }
+    
+    
     // - MARK: Initializers
     
     /**

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -402,7 +402,7 @@ public extension APIClient {
      
      - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
      
-     - returns: The list of answers as `APIResponse<Question>`
+     - returns: The list of questions as `APIResponse<Question>`
      
      - authors: NobodyNada, FelixSFD
      */
@@ -462,7 +462,7 @@ public extension APIClient {
      
      - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
      
-     - returns: The list of answers as `APIResponse<Question>`
+     - returns: The list of questions as `APIResponse<Question>`
      
      - authors: NobodyNada, FelixSFD
      */
@@ -493,6 +493,112 @@ public extension APIClient {
         completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
         
         fetchLinkedQuestionsTo(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
+    }
+    
+    
+    
+    // - MARK: /questions/{ids}/related
+    
+    /**
+     Fetches related `Question`s to `Question`s synchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of questions as `APIResponse<Question>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchRelatedQuestionsTo(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
+        
+        guard !ids.isEmpty else {
+            fatalError("ids is empty")
+        }
+        
+        
+        return try performAPIRequest(
+            "questions/\(ids.map {String($0)}.joined(separator: ";"))/related",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches related `Question`s to `Question`s asynchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchRelatedQuestionsTo(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Question> = try self.fetchRelatedQuestionsTo(questions: ids, parameters: parameters, backoffBehavior: backoffBehavior)
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    /**
+     Fetches related `Question`s to a single `Question` synchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of questions as `APIResponse<Question>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchRelatedQuestionsTo(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
+        return try fetchRelatedQuestionsTo(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior)
+    }
+    
+    /**
+     Fetches related `Question`s to a single `Question`  asynchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchRelatedQuestionsTo(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
+        
+        fetchRelatedQuestionsTo(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
     }
 	
 }

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -15,7 +15,59 @@ This extension contains all requests in the SITES section of the StackExchange A
 - author: NobodyNada, FelixSFD
 */
 public extension APIClient {
-	
+	// - MARK: /questions
+    /**
+     Fetches all questions on the site synchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an APIRequest has a backoff
+     
+     - returns: The list of sites as `APIResponse<Question>`
+     
+     - author: FelixSFD
+     */
+    public func fetchQuestions(
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
+        
+        return try performAPIRequest(
+            "questions",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches all questions on the site asynchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an APIRequest has a backoff
+     
+     - parameter completion
+     
+     - author: FelixSFD
+     */
+    public func fetchQuestions(
+        parameters: [String: String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Question> = try self.fetchQuestions(
+                    parameters: parameters,
+                    backoffBehavior: backoffBehavior
+                )
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
 	// - MARK: /questions/{ids}
     /**
      Fetches questions synchronously.

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -388,5 +388,111 @@ public extension APIClient {
         
         fetchCommentsOn(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
     }
+    
+    
+    
+    // - MARK: /questions/{ids}/linked
+    
+    /**
+     Fetches linked `Question`s to `Question`s synchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of answers as `APIResponse<Question>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchLinkedQuestionsTo(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
+        
+        guard !ids.isEmpty else {
+            fatalError("ids is empty")
+        }
+        
+        
+        return try performAPIRequest(
+            "questions/\(ids.map {String($0)}.joined(separator: ";"))/linked",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches linked `Question`s to `Question`s asynchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchLinkedQuestionsTo(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Question> = try self.fetchLinkedQuestionsTo(questions: ids, parameters: parameters, backoffBehavior: backoffBehavior)
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    /**
+     Fetches linked `Question`s to a single `Question` synchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of answers as `APIResponse<Question>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchLinkedQuestionsTo(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
+        return try fetchLinkedQuestionsTo(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior)
+    }
+    
+    /**
+     Fetches linked `Question`s to a single `Question`  asynchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchLinkedQuestionsTo(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
+        
+        fetchLinkedQuestionsTo(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
+    }
 	
 }

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -68,6 +68,7 @@ public extension APIClient {
         }
     }
     
+    
 	// - MARK: /questions/{ids}
     /**
      Fetches questions synchronously.
@@ -176,6 +177,112 @@ public extension APIClient {
 		
 		fetchQuestions([id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
 	}
+    
+    
+    // - MARK: /questions/{ids}/answers
+    
+    /**
+     Fetches `Answer`s on `Question`s synchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of answers as `APIResponse<Answer>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchAnswersOn(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Answer> {
+        
+        guard !ids.isEmpty else {
+            fatalError("ids is empty")
+        }
+        
+        
+        return try performAPIRequest(
+            "questions/\(ids.map {String($0)}.joined(separator: ";"))/answers",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches `Answer`s on `Question`s asynchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchAnswersOn(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Answer>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Answer> = try self.fetchAnswersOn(questions: ids, parameters: parameters, backoffBehavior: backoffBehavior)
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    /**
+     Fetches `Answer`s on a single `Question` synchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of answers as `APIResponse<Answer>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchAnswersOn(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Answer> {
+        return try fetchAnswersOn(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior)
+    }
+    
+    /**
+     Fetches `Answer`s on a single `Question` asynchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchAnswersOn(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Answer>?, Error?) -> ()) {
+        
+        fetchAnswersOn(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
+    }
+    
     
     
     // - MARK: /questions/{ids}/comments

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -12,7 +12,7 @@ import Dispatch
 /**
 This extension contains all requests in the SITES section of the StackExchange API Documentation.
 
-- author: NobodyNada
+- author: NobodyNada, FelixSFD
 */
 public extension APIClient {
 	
@@ -124,5 +124,110 @@ public extension APIClient {
 		
 		fetchQuestions([id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
 	}
+    
+    
+    // - MARK: /questions/{ids}/comments
+    
+    /**
+     Fetches `Comment`s on `Question`s synchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of comments as `APIResponse<Comment>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchCommentsOn(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Comment> {
+        
+        guard !ids.isEmpty else {
+            fatalError("ids is empty")
+        }
+        
+        
+        return try performAPIRequest(
+            "questions/\(ids.map {String($0)}.joined(separator: ";"))/comments",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches `Comment`s on `Question`s asynchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchCommentsOn(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Comment>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Comment> = try self.fetchCommentsOn(questions: ids, parameters: parameters, backoffBehavior: backoffBehavior)
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    /**
+     Fetches `Comment`s on a single `Question` synchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of comments as `APIResponse<Comment>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchCommentsOn(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Comment> {
+        return try fetchCommentsOn(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior)
+    }
+    
+    /**
+     Fetches `Comment`s on a single `Question` asynchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchCommentsOn(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Comment>?, Error?) -> ()) {
+        
+        fetchCommentsOn(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
+    }
 	
 }

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -668,6 +668,8 @@ public extension APIClient {
      
      - returns: The list of questions as `APIResponse<Question>`
      
+     - seealso: fetchUnansweredQuestions(parameters:backoffBehavior:)
+     
      - author: FelixSFD
      */
     public func fetchQuestionsWithNoAnswers(
@@ -690,6 +692,8 @@ public extension APIClient {
      
      - parameter completion
      
+     - seealso: fetchUnansweredQuestions(parameters:backoffBehavior:completionHandler:)
+     
      - author: FelixSFD
      */
     public func fetchQuestionsWithNoAnswers(
@@ -710,5 +714,65 @@ public extension APIClient {
             }
         }
     }
+    
+    
+    
+    // - MARK: /questions/unanswered
+    /**
+     Fetches all questions the site considers unanswered synchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of questions as `APIResponse<Question>`
+     
+     - seealso: fetchQuestionsWithNoAnswers(parameters:backoffBehavior:)
+     
+     - author: FelixSFD
+     */
+    public func fetchUnansweredQuestions(
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
+        
+        return try performAPIRequest(
+            "questions/unanswered",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches all questions the site considers unanswered asynchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completion
+     
+     - seealso: fetchQuestionsWithNoAnswers(parameters:backoffBehavior:completionHandler:)
+     
+     - author: FelixSFD
+     */
+    public func fetchUnansweredQuestions(
+        parameters: [String: String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Question> = try self.fetchQuestions(
+                    parameters: parameters,
+                    backoffBehavior: backoffBehavior
+                )
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+    }
+
 	
 }

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -23,7 +23,7 @@ public extension APIClient {
      
      - parameter backoffBehavior: The behavior when an APIRequest has a backoff
      
-     - returns: The list of sites as `APIResponse<Question>`
+     - returns: The list of questions as `APIResponse<Question>`
      
      - author: FelixSFD
      */
@@ -599,6 +599,61 @@ public extension APIClient {
         completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
         
         fetchRelatedQuestionsTo(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
+    }
+    
+    
+    
+    // - MARK: /questions/featured
+    /**
+     Fetches all questions with active bounties on the site synchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of questions as `APIResponse<Question>`
+     
+     - author: FelixSFD
+     */
+    public func fetchFeaturedQuestions(
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
+        
+        return try performAPIRequest(
+            "questions/featured",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches all questions with active bounties on the site asynchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completion
+     
+     - author: FelixSFD
+     */
+    public func fetchFeaturedQuestions(
+        parameters: [String: String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Question> = try self.fetchQuestions(
+                    parameters: parameters,
+                    backoffBehavior: backoffBehavior
+                )
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
     }
 	
 }

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -603,6 +603,112 @@ public extension APIClient {
     
     
     
+    // - MARK: /questions/{ids}/timeline
+    
+    /**
+     Fetches the `Question.Timeline` events of `Question`s synchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of questions as `APIResponse<Question.Timeline>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchTimelineOf(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question.Timeline> {
+        
+        guard !ids.isEmpty else {
+            fatalError("ids is empty")
+        }
+        
+        
+        return try performAPIRequest(
+            "questions/\(ids.map {String($0)}.joined(separator: ";"))/timeline",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches the `Question.Timeline` events of `Question`s asynchronously.
+     
+     - parameter ids: The question IDs to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchTimelineOf(
+        questions ids: [Int],
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question.Timeline>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Question.Timeline> = try self.fetchTimelineOf(questions: ids, parameters: parameters, backoffBehavior: backoffBehavior)
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    /**
+     Fetches the `Question.Timeline` events of a single `Question` synchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of questions as `APIResponse<Question.Timeline>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchTimelineOf(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question.Timeline> {
+        return try fetchTimelineOf(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior)
+    }
+    
+    /**
+     Fetches the `Question.Timeline` events of a single `Question` asynchronously.
+     
+     - parameter id: The question ID to fetch.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler:
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchTimelineOf(
+        question id: Int,
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question.Timeline>?, Error?) -> ()) {
+        
+        fetchTimelineOf(questions: [id], parameters: parameters, backoffBehavior: backoffBehavior, completionHandler: completionHandler)
+    }
+    
+    
+    
     // - MARK: /questions/featured
     /**
      Fetches all questions with active bounties on the site synchronously.

--- a/Sources/RequestsQuestions.swift
+++ b/Sources/RequestsQuestions.swift
@@ -655,5 +655,60 @@ public extension APIClient {
             }
         }
     }
+    
+    
+    
+    // - MARK: /questions/no-answers
+    /**
+     Fetches all questions with no answers on the site synchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of questions as `APIResponse<Question>`
+     
+     - author: FelixSFD
+     */
+    public func fetchQuestionsWithNoAnswers(
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Question> {
+        
+        return try performAPIRequest(
+            "questions/no-answers",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches all questions with no answers on the site asynchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completion
+     
+     - author: FelixSFD
+     */
+    public func fetchQuestionsWithNoAnswers(
+        parameters: [String: String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Question>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Question> = try self.fetchQuestions(
+                    parameters: parameters,
+                    backoffBehavior: backoffBehavior
+                )
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+    }
 	
 }

--- a/Tests/SwiftStackTests/QuestionTests.swift
+++ b/Tests/SwiftStackTests/QuestionTests.swift
@@ -398,4 +398,53 @@ class QuestionTests: APITests {
         waitForExpectations(timeout: 10, handler: nil)
     }
     
+    
+    
+    // - MARK: Test unanswered questions
+    
+    func testFetchUnansweredQuestionsSync() {
+        let id = 13371337
+        client.onRequest { task in
+            return ("{\"items\": [{\"question_id\": \(id)}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        do {
+            let response = try client.fetchUnansweredQuestions()
+            XCTAssertNotNil(response.items, "items is nil")
+            XCTAssertEqual(response.items?.first?.post_id, id, "id was incorrect")
+            
+        } catch {
+            print(error)
+            XCTFail("fetchQuestionsWithNoAnswers threw an error")
+        }
+    }
+    
+    func testFetchUnansweredQuestionsAsync() {
+        expectation = expectation(description: "Fetched questions")
+        
+        let id = 13371337
+        client.onRequest { task in
+            return ("{\"items\": [{\"question_id\": \(id)}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        client.fetchUnansweredQuestions(parameters: [:], backoffBehavior: .wait) {
+            response, error in
+            if error != nil {
+                print(error!)
+                XCTFail("Questions not fetched")
+                return
+            }
+            
+            print(response?.items ?? "no items")
+            
+            if response?.items?.first?.post_id == id {
+                self.expectation?.fulfill()
+            } else {
+                XCTFail("id was incorrect")
+            }
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
 }

--- a/Tests/SwiftStackTests/QuestionTests.swift
+++ b/Tests/SwiftStackTests/QuestionTests.swift
@@ -1,0 +1,110 @@
+//
+//  QuestionTests.swift
+//  SwiftStack
+//
+//  Created by Felix Deil on 04.01.17.
+//
+//
+
+import XCTest
+
+class QuestionTests: APITests {
+    
+    // - MARK: Test question
+    
+    func testFetchQuestionSync() {
+        let id = 41463556
+        client.onRequest { task in
+            return ("{\"items\": [{\"question_id\": \(id)}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        do {
+            let response = try client.fetchQuestion(id)
+            XCTAssertNotNil(response.items, "items is nil")
+            XCTAssertEqual(response.items?.first?.post_id, id, "id was incorrect")
+            
+        } catch {
+            print(error)
+            XCTFail("fetchQuestion threw an error")
+        }
+    }
+    
+    func testFetchQuestionAsync() {
+        expectation = expectation(description: "Fetched comments")
+        
+        let id = 41463556
+        
+        client.onRequest { task in
+            return ("{\"items\": [{\"question_id\": \(id)}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        client.fetchQuestion(id, parameters: [:], backoffBehavior: .wait) {
+            response, error in
+            if error != nil {
+                print(error!)
+                XCTFail("Question not fetched")
+                return
+            }
+            
+            print(response?.items ?? "no items")
+            
+            if response?.items?.first?.post_id == id {
+                self.expectation?.fulfill()
+            } else {
+                XCTFail("id was incorrect")
+            }
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    
+    // - MARK: Test comments on question
+    
+    func testFetchCommentsOnQuestionSync() {
+        let id = 41463556
+        client.onRequest { task in
+            return ("{\"items\": [{\"post_id\": \(id), \"comment_id\": 13371337}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        do {
+            let response = try client.fetchCommentsOn(question: id)
+            XCTAssertNotNil(response.items, "items is nil")
+            XCTAssertEqual(response.items?.first?.post_id, id, "id was incorrect")
+            
+        } catch {
+            print(error)
+            XCTFail("fetchCommentsOn(question:) threw an error")
+        }
+    }
+    
+    func testFetchCommentsOnQuestionAsync() {
+        expectation = expectation(description: "Fetched comments")
+        
+        let id = 41463556
+        
+        client.onRequest { task in
+            return ("{\"items\": [{\"post_id\": \(id), \"comment_id\": 13371337}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        client.fetchCommentsOn(question: id, parameters: [:], backoffBehavior: .wait) {
+            response, error in
+            if error != nil {
+                print(error!)
+                XCTFail("Comments not fetched")
+                return
+            }
+            
+            print(response?.items ?? "no items")
+            
+            if response?.items?.first?.post_id == id {
+                self.expectation?.fulfill()
+            } else {
+                XCTFail("id was incorrect")
+            }
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+}

--- a/Tests/SwiftStackTests/QuestionTests.swift
+++ b/Tests/SwiftStackTests/QuestionTests.swift
@@ -349,4 +349,53 @@ class QuestionTests: APITests {
         waitForExpectations(timeout: 10, handler: nil)
     }
     
+    
+    
+    // - MARK: Test questions with no answers
+    
+    func testFetchQuestionsWithNoAnswersSync() {
+        let id = 13371337
+        client.onRequest { task in
+            return ("{\"items\": [{\"question_id\": \(id)}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        do {
+            let response = try client.fetchQuestionsWithNoAnswers()
+            XCTAssertNotNil(response.items, "items is nil")
+            XCTAssertEqual(response.items?.first?.post_id, id, "id was incorrect")
+            
+        } catch {
+            print(error)
+            XCTFail("fetchQuestionsWithNoAnswers threw an error")
+        }
+    }
+    
+    func testFetchQuestionsWithNoAnswersAsync() {
+        expectation = expectation(description: "Fetched questions")
+        
+        let id = 13371337
+        client.onRequest { task in
+            return ("{\"items\": [{\"question_id\": \(id)}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        client.fetchQuestionsWithNoAnswers(parameters: [:], backoffBehavior: .wait) {
+            response, error in
+            if error != nil {
+                print(error!)
+                XCTFail("Questions not fetched")
+                return
+            }
+            
+            print(response?.items ?? "no items")
+            
+            if response?.items?.first?.post_id == id {
+                self.expectation?.fulfill()
+            } else {
+                XCTFail("id was incorrect")
+            }
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
 }


### PR DESCRIPTION
I have implemented requests for everything in the **questions**-section that returns a list of `Comment`, `Answer`, `Question` or `Question.Timeline` and does not require authentication.