### PR TITLE
Feature/22 privileges

### DIFF
--- a/Sources/Privilege.swift
+++ b/Sources/Privilege.swift
@@ -1,0 +1,85 @@
+//
+//  Privilege.swift
+//  SwiftStack
+//
+//  Created by FelixSFD on 14.02.17.
+//
+//
+
+import Foundation
+
+/**
+ Represents a privilege a user may have on a Stack Exchange site.
+ 
+ - author: FelixSFD
+ 
+ - seealso: [StackExchange API](https://api.stackexchange.com/docs/types/privilege)
+ */
+public class Privilege: JsonConvertible, CustomStringConvertible {
+    
+    // - MARK: Initializers
+    
+    /**
+     Initializes the object from a JSON string.
+     
+     - parameter json: The JSON string returned by the API
+     
+     - author: FelixSFD
+     */
+    public convenience required init?(jsonString json: String) {
+        do {
+            guard let dictionary = try JSONSerialization.jsonObject(with: json.data(using: String.Encoding.utf8)!, options: .allowFragments) as? [String: Any] else {
+                return nil
+            }
+            
+            self.init(dictionary: dictionary)
+        } catch {
+            return nil
+        }
+    }
+    
+    public required init(dictionary: [String: Any]) {
+        description = (dictionary["description"] as? String)?.stringByDecodingHTMLEntities
+        reputation = dictionary["reputation"] as? Int
+        short_description = (dictionary["short_description"] as? String)?.stringByDecodingHTMLEntities
+    }
+    
+    /**
+     Basic initializer without any parameters
+     */
+    public init() { }
+    
+    
+    // - MARK: JsonConvertible
+    
+    public var dictionary: [String: Any] {
+        var dict = [String: Any]()
+        
+        dict["description"] = description
+        dict["reputation"] = reputation
+        dict["short_description"] = short_description
+        
+        return dict
+    }
+    
+    public var jsonString: String? {
+        return (try? JsonHelper.jsonString(from: self)) ?? nil
+    }
+    
+    
+    // - MARK: CustomStringConvertible
+    
+    public var description: String {
+        return "\(dictionary)"
+    }
+    
+    
+    // - MARK: Values returned from API
+    
+    public var description: String?
+    
+    public var reputation: Int?
+    
+    public var short_description: String?
+    
+}

--- a/Sources/Privilege.swift
+++ b/Sources/Privilege.swift
@@ -39,7 +39,7 @@ public class Privilege: JsonConvertible, CustomStringConvertible {
     }
     
     public required init(dictionary: [String: Any]) {
-        description = (dictionary["description"] as? String)?.stringByDecodingHTMLEntities
+        description = (dictionary["description"] as? String)?.stringByDecodingHTMLEntities ?? ""
         reputation = dictionary["reputation"] as? Int
         short_description = (dictionary["short_description"] as? String)?.stringByDecodingHTMLEntities
     }
@@ -47,7 +47,9 @@ public class Privilege: JsonConvertible, CustomStringConvertible {
     /**
      Basic initializer without any parameters
      */
-    public init() { }
+    public init() {
+        description = ""
+    }
     
     
     // - MARK: JsonConvertible
@@ -67,16 +69,12 @@ public class Privilege: JsonConvertible, CustomStringConvertible {
     }
     
     
-    // - MARK: CustomStringConvertible
-    
-    public var description: String {
-        return "\(dictionary)"
-    }
-    
-    
     // - MARK: Values returned from API
     
-    public var description: String?
+    /**
+     - note: Not optional due to overlap with the `CustomStringConvertible`-protocol.
+     */
+    public var description: String
     
     public var reputation: Int?
     

--- a/Sources/RequestsPrivileges.swift
+++ b/Sources/RequestsPrivileges.swift
@@ -1,0 +1,73 @@
+//
+//  RequestsPrivileges.swift
+//  SwiftStack
+//
+//  Created by FelixSFD on 14.02.17.
+//
+//
+
+import Foundation
+
+/**
+ This extension contains all requests in the PRIVILEGES section of the StackExchange API Documentation.
+ 
+ - authors: NobodyNada, FelixSFD
+ */
+public extension APIClient {
+    
+    // - MARK: /privileges
+    
+    /**
+     Fetches all `Privileges`s synchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - returns: The list of sites as `APIResponse<Privilege>`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchPrivileges(
+        parameters: [String:String] = [:],
+        backoffBehavior: BackoffBehavior = .wait) throws -> APIResponse<Privilege> {
+        
+        
+        return try performAPIRequest(
+            "privileges",
+            parameters: parameters,
+            backoffBehavior: backoffBehavior
+        )
+    }
+    
+    /**
+     Fetches all `Privileges`s asynchronously.
+     
+     - parameter parameters: The dictionary of parameters used in the request
+     
+     - parameter backoffBehavior: The behavior when an `APIRequest` has a backoff
+     
+     - parameter completionHandler: Passes either an `APIResponse<Privilege>?` or an `Error?`
+     
+     - authors: NobodyNada, FelixSFD
+     */
+    public func fetchPrivileges(
+        parameters: [String: String] = [:],
+        backoffBehavior: BackoffBehavior = .wait,
+        completionHandler: @escaping (APIResponse<Privilege>?, Error?) -> ()) {
+        
+        queue.async {
+            do {
+                let response: APIResponse<Privilege> = try self.fetchPrivileges(
+                    parameters: parameters,
+                    backoffBehavior: backoffBehavior
+                )
+                
+                completionHandler(response, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+    }
+}
+

--- a/Tests/SwiftStackTests/PrivilegesTests.swift
+++ b/Tests/SwiftStackTests/PrivilegesTests.swift
@@ -1,0 +1,58 @@
+//
+//  PrivilegesTests.swift
+//  SwiftStack
+//
+//  Created by FelixSFD on 14.02.17.
+//
+//
+
+import XCTest
+import SwiftStack
+
+class PrivilegesTests: APITests {
+    
+    
+    func testFetchPrivilegesSync() {
+        client.onRequest { task in
+            return ("{\"items\": [{\"reputation\": 25000, \"description\": \"Access to internal and Google site analytics\", \"short_description\": \"access to site analytics\"}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        do {
+            let response = try client.fetchPrivileges()
+            XCTAssertNotNil(response.items, "items is nil")
+            XCTAssertEqual(response.items?.first?.reputation, 25000, "rep was incorrect")
+            
+        } catch {
+            print(error)
+            XCTFail("fetchPrivileges threw an error")
+        }
+    }
+    
+    func testFetchPrivilegesAsync() {
+        expectation = expectation(description: "Fetched privileges")
+        
+        client.onRequest { task in
+            return ("{\"items\": [{\"reputation\": 25000, \"description\": \"Access to internal and Google site analytics\", \"short_description\": \"access to site analytics\"}]}".data(using: .utf8), self.blankResponse(task), nil)
+        }
+        
+        client.fetchPrivileges(parameters: [:], backoffBehavior: .wait) {
+            response, error in
+            if error != nil {
+                print(error!)
+                XCTFail("Privileges not fetched")
+                return
+            }
+            
+            print(response?.items ?? "no items")
+            
+            if response?.items?.first?.reputation == 25000 {
+                self.expectation?.fulfill()
+            } else {
+                XCTFail("rep was incorrect")
+            }
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+}


### PR DESCRIPTION
Implemented `Privilege` and the requests for `/privileges`.

`Privilege.description` is a bit odd. The `CustomStringConvertibleProtocol` needs this property non-optinal. That's why I'm using an empty `String`, if no description was sent.

Closes #22 