### PR TITLE
Feature/fewer prints

### DIFF
--- a/Tests/SwiftStackTests/APITests.swift
+++ b/Tests/SwiftStackTests/APITests.swift
@@ -113,6 +113,8 @@ class APITests: XCTestCase {
 	
 	//MARK: - Tests
 	func testRequest() throws {
+		XCTAssertNotNil(client, "client should not be nil")
+		
 		let expectedHost = "api.stackexchange.com"
 		let expectedPath = "/2.2/info"
 		let expectedParameters = ["site":"stackoverflow", "filter":"default"]
@@ -120,7 +122,8 @@ class APITests: XCTestCase {
 		client.defaultSite = "stackoverflow"
 		client.defaultFilter = "default"
 		client.onRequest {task in
-			let url = task.currentRequest!.url!
+			let url: URL! = task.currentRequest?.url
+			XCTAssertNotNil(url, "url should not be nil")
 			
 			let actualHost = url.host
 			let actualPath = url.path

--- a/Tests/SwiftStackTests/APITests.swift
+++ b/Tests/SwiftStackTests/APITests.swift
@@ -122,7 +122,7 @@ class APITests: XCTestCase {
 		client.defaultSite = "stackoverflow"
 		client.defaultFilter = "default"
 		client.onRequest {task in
-			let url: URL! = task.currentRequest?.url
+			let url: URL! = task.originalRequest?.url
 			XCTAssertNotNil(url, "url should not be nil")
 			
 			let actualHost = url.host

--- a/Tests/SwiftStackTests/APITests.swift
+++ b/Tests/SwiftStackTests/APITests.swift
@@ -63,10 +63,9 @@ class APITests: XCTestCase {
 			("testBackoffCleanup", testBackoffCleanup),
 			
 			("testFetchSitesSync", testFetchSitesSync),
-			("testFetchSitesASync", testFetchSitesASync),
+			("testFetchSitesAsync", testFetchSitesAsync),
 			
 			("testFetchRevisionSync", testFetchRevisionsSync),
-			("testFetchRevisionSync", testFetchRevisionSync),
 			("testFetchRevisionAsync", testFetchRevisionAsync),
 			
 			("testFetchSuggestedEditsSync", testFetchSuggestedEditsSync),
@@ -192,10 +191,10 @@ class APITests: XCTestCase {
 		let _ = try client.performAPIRequest("info") as APIResponse<Site>
 		
 		XCTAssert(client.quota == expectedQuota,
-		          "quota \"\(client.quota)\" is incorrect (should be \"\(expectedQuota)\")")
+		          "quota \"\(String(describing: client.quota))\" is incorrect (should be \"\(expectedQuota)\")")
 		
 		XCTAssert(client.maxQuota == expectedMaxQuota,
-		          "quotaMax \"\(client.maxQuota)\" is incorrect (should be \"\(expectedMaxQuota)\")")
+		          "quotaMax \"\(String(describing: client.maxQuota))\" is incorrect (should be \"\(expectedMaxQuota)\")")
 	}
 	
 	
@@ -304,9 +303,13 @@ class APITests: XCTestCase {
                 XCTFail("Sites not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
-            self.expectation?.fulfill()
+			
+			if response?.items?.first?.name == "Test Site" {
+				self.expectation?.fulfill()
+			} else {
+				print(response?.items ?? "no items")
+				XCTFail("name was incorrect")
+			}
         }
         
         waitForExpectations(timeout: 30, handler: nil)

--- a/Tests/SwiftStackTests/AnswersTests.swift
+++ b/Tests/SwiftStackTests/AnswersTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 
 class AnswersTests: APITests {
-    
+	
     // - MARK: Test answers
     
     func testFetchAnswerSync() {
@@ -46,15 +46,14 @@ class AnswersTests: APITests {
                 return
             }
             
-            print(response?.items ?? "no items")
-            
             if response?.items?.first?.answer_id == id {
                 self.expectation?.fulfill()
-            } else {
-                XCTFail("id was incorrect")
+			} else {
+				print(response?.items ?? "no items")
+				XCTFail("id was incorrect")
             }
         }
-        
+		
         waitForExpectations(timeout: 10, handler: nil)
     }
     
@@ -94,13 +93,13 @@ class AnswersTests: APITests {
                 XCTFail("Answers not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.answer_id == id {
                 self.expectation?.fulfill()
-            } else {
-                XCTFail("id was incorrect")
+			} else {
+				print(response?.items ?? "no items")
+				XCTFail("id was incorrect")
             }
         }
         
@@ -143,13 +142,13 @@ class AnswersTests: APITests {
                 XCTFail("Comments not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.post_id == id {
                 self.expectation?.fulfill()
-            } else {
-                XCTFail("id was incorrect")
+			} else {
+				print(response?.items ?? "no items")
+				XCTFail("id was incorrect")
             }
         }
         
@@ -192,13 +191,13 @@ class AnswersTests: APITests {
                 XCTFail("Question not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.question_id == id {
                 self.expectation?.fulfill()
-            } else {
-                XCTFail("id was incorrect")
+			} else {
+				print(response?.items ?? "no items")
+				XCTFail("id was incorrect")
             }
         }
         

--- a/Tests/SwiftStackTests/JsonHelperTests.swift
+++ b/Tests/SwiftStackTests/JsonHelperTests.swift
@@ -20,9 +20,9 @@ class JsonHelperTests: XCTestCase {
         
         print(encoded)
         XCTAssertNotNil(encoded)*/
-        
+		
 		let jsonUser = user?.jsonString
-		print(jsonUser ?? "nil")
+		//print(jsonUser ?? "nil")
 		XCTAssertNotNil(jsonUser)
     }
     

--- a/Tests/SwiftStackTests/PostTests.swift
+++ b/Tests/SwiftStackTests/PostTests.swift
@@ -16,7 +16,7 @@ class PostTests: XCTestCase {
         
         let question = Question(jsonString: json)
         let jsonQuestion = question?.jsonString
-        print(jsonQuestion ?? "nil")
+        //print(jsonQuestion ?? "nil")
         XCTAssertNotNil(jsonQuestion)
     }
     
@@ -25,7 +25,7 @@ class PostTests: XCTestCase {
         
         let answer = Answer(jsonString: json)
         let jsonAnswer = answer?.jsonString
-        print(jsonAnswer ?? "nil")
+        //print(jsonAnswer ?? "nil")
         XCTAssertNotNil(jsonAnswer)
     }
     

--- a/Tests/SwiftStackTests/QuestionTests.swift
+++ b/Tests/SwiftStackTests/QuestionTests.swift
@@ -20,9 +20,8 @@ class QuestionTests: APITests {
         
         do {
             let response = try client.fetchQuestion(id)
-            print(response.items?.first?.title ?? "nil")
             XCTAssertNotNil(response.items, "items is nil")
-            XCTAssertEqual(response.items?.first?.post_id, id, "id was incorrect")
+			XCTAssertEqual(response.items?.first?.post_id, id, "id was incorrect (was \(String(describing: response.items?.first?.post_id))")
             
         } catch {
             print(error)
@@ -46,13 +45,13 @@ class QuestionTests: APITests {
                 XCTFail("Question not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
-            print(response?.items?.first?.title ?? "nil")
+			
             
             if response?.items?.first?.post_id == id {
                 self.expectation?.fulfill()
-            } else {
+			} else {
+				print(response?.items ?? "no items")
+				print(response?.items?.first?.title ?? "nil")
                 XCTFail("id was incorrect")
             }
         }
@@ -97,12 +96,11 @@ class QuestionTests: APITests {
                 return
             }
             
-            print(response?.items ?? "no items")
-            
             if response?.items?.first?.post_id == id {
                 self.expectation?.fulfill()
-            } else {
-                XCTFail("id was incorrect")
+			} else {
+				print(response?.items ?? "no items")
+				XCTFail("id was incorrect")
             }
         }
         
@@ -144,12 +142,12 @@ class QuestionTests: APITests {
                 XCTFail("Answers not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.answer_id == id {
                 self.expectation?.fulfill()
-            } else {
+			} else {
+				print(response?.items ?? "no items")
                 XCTFail("id was incorrect")
             }
         }
@@ -193,12 +191,12 @@ class QuestionTests: APITests {
                 XCTFail("Comments not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.post_id == id {
                 self.expectation?.fulfill()
-            } else {
+			} else {
+				print(response?.items ?? "no items")
                 XCTFail("id was incorrect")
             }
         }
@@ -241,12 +239,12 @@ class QuestionTests: APITests {
                 XCTFail("Questions not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.question_id == id {
                 self.expectation?.fulfill()
-            } else {
+			} else {
+				print(response?.items ?? "no items")
                 XCTFail("id was incorrect")
             }
         }
@@ -288,12 +286,12 @@ class QuestionTests: APITests {
                 XCTFail("Questions not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.question_id == id {
                 self.expectation?.fulfill()
-            } else {
+			} else {
+				print(response?.items ?? "no items")
                 XCTFail("id was incorrect")
             }
         }
@@ -338,12 +336,12 @@ class QuestionTests: APITests {
                 XCTFail("Questions not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.post_id == id {
                 self.expectation?.fulfill()
-            } else {
+			} else {
+				print(response?.items ?? "no items")
                 XCTFail("id was incorrect")
             }
         }
@@ -387,12 +385,12 @@ class QuestionTests: APITests {
                 XCTFail("Timeline not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.question_id == id {
                 self.expectation?.fulfill()
-            } else {
+			} else {
+				print(response?.items ?? "no items")
                 XCTFail("id was incorrect")
             }
         }
@@ -436,12 +434,12 @@ class QuestionTests: APITests {
                 XCTFail("Questions not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.post_id == id {
                 self.expectation?.fulfill()
-            } else {
+			} else {
+				print(response?.items ?? "no items")
                 XCTFail("id was incorrect")
             }
         }
@@ -485,12 +483,12 @@ class QuestionTests: APITests {
                 XCTFail("Questions not fetched")
                 return
             }
-            
-            print(response?.items ?? "no items")
+			
             
             if response?.items?.first?.post_id == id {
                 self.expectation?.fulfill()
-            } else {
+			} else {
+				print(response?.items ?? "no items")
                 XCTFail("id was incorrect")
             }
         }

--- a/Tests/SwiftStackTests/SiteTests.swift
+++ b/Tests/SwiftStackTests/SiteTests.swift
@@ -20,7 +20,7 @@ class SiteTests: XCTestCase {
         
         let site = Site(jsonString: json)
         let jsonSite = site?.jsonString
-        print(jsonSite ?? "nil")
+        //print(jsonSite ?? "nil")
         XCTAssertNotNil(jsonSite)
     }
     

--- a/Tests/SwiftStackTests/UserTests.swift
+++ b/Tests/SwiftStackTests/UserTests.swift
@@ -21,7 +21,7 @@ class UserTests: XCTestCase {
         let json = "{\"badge_counts\": {\"bronze\": 3,\"silver\": 2,\"gold\": 1},\"view_count\": 1000,\"down_vote_count\": 50,\"up_vote_count\": 90,\"answer_count\": 10,\"question_count\": 12,\"account_id\": 1,\"is_employee\": false,\"last_modified_date\": 1480858104,\"last_access_date\": 1480901304,\"age\": 40,\"reputation_change_year\": 9001,\"reputation_change_quarter\": 400,\"reputation_change_month\": 200,\"reputation_change_week\": 800,\"reputation_change_day\": 100,\"reputation\": 9001,\"creation_date\": 1480858104,\"user_type\": \"registered\",\"user_id\": 1,\"accept_rate\": 55,\"about_me\": \"about me block\",\"location\": \"An Imaginary World\",\"website_url\": \"http://example.com/\",\"link\": \"http://example.stackexchange.com/users/1/example-user\",\"profile_image\": \"https://www.gravatar.com/avatar/a007be5a61f6aa8f3e85ae2fc18dd66e?d=identicon&r=PG\",\"display_name\": \"Example User\"}"
         
         let user = User(jsonString: json)
-        print(user ?? "nil")
+        //print(user ?? "nil")
         
         if user?.jsonString == nil {
             XCTFail("User could not be represented as JSON!")


### PR DESCRIPTION
Remove prints from unit tests unless a test fails, to keep the test log clean.

This also fixes unit tests on Linux.